### PR TITLE
Resolve github actions dependency lock error

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,20 +10,24 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: '16'
+          node-version: '18'
           cache: 'npm'
+          cache-dependency-path: 'Musicboxd/package-lock.json'
           
       - name: Install dependencies
+        working-directory: ./Musicboxd
         run: npm ci
         
       - name: Run linting
+        working-directory: ./Musicboxd
         run: npm run lint
         
       # This will be enabled once we have testing set up
       # - name: Run tests
+      #   working-directory: ./Musicboxd
       #   run: npm test 


### PR DESCRIPTION
Update GitHub Actions workflow to fix linting errors and use current action versions.

The previous workflow failed because it was looking for dependency lock files in the wrong directory and used outdated action versions. This PR corrects the working directory for npm commands, updates actions to their latest versions (v4), and aligns the Node.js version with project requirements (v18).

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-0632fcdd-e545-4266-a1c5-98a197e5648b) · [Cursor](https://cursor.com/background-agent?bcId=bc-0632fcdd-e545-4266-a1c5-98a197e5648b)

Learn more about [Background Agents](https://docs.cursor.com/background-agents)