### PR TITLE
Enable album tracking and ratings

### DIFF
--- a/Musicboxd/src/navigation/AppNavigator.tsx
+++ b/Musicboxd/src/navigation/AppNavigator.tsx
@@ -13,6 +13,8 @@ import SearchScreen from '../screens/Search/SearchScreen';
 import ProfileScreen from '../screens/Profile/ProfileScreen';
 import UserProfileScreen from '../screens/Profile/UserProfileScreen';
 import FollowersScreen from '../screens/Profile/FollowersScreen';
+import ListenedAlbumsScreen from '../screens/Profile/ListenedAlbumsScreen';
+import UserReviewsScreen from '../screens/Profile/UserReviewsScreen';
 import AlbumDetailsScreen from '../screens/Album/AlbumDetailsScreen';
 import AuthScreen from '../screens/Auth/AuthScreen';
 
@@ -89,6 +91,20 @@ function HomeStackNavigator() {
           headerShown: false,
         }}
       />
+      <HomeStack.Screen
+        name="ListenedAlbums"
+        component={ListenedAlbumsScreen}
+        options={{
+          headerShown: false,
+        }}
+      />
+      <HomeStack.Screen
+        name="UserReviews"
+        component={UserReviewsScreen}
+        options={{
+          headerShown: false,
+        }}
+      />
     </HomeStack.Navigator>
   );
 }
@@ -132,6 +148,20 @@ function SearchStackNavigator() {
           headerShown: false,
         }}
       />
+      <SearchStack.Screen
+        name="ListenedAlbums"
+        component={ListenedAlbumsScreen}
+        options={{
+          headerShown: false,
+        }}
+      />
+      <SearchStack.Screen
+        name="UserReviews"
+        component={UserReviewsScreen}
+        options={{
+          headerShown: false,
+        }}
+      />
     </SearchStack.Navigator>
   );
 }
@@ -164,6 +194,20 @@ function ProfileStackNavigator() {
       <ProfileStack.Screen
         name="Followers"
         component={FollowersScreen}
+        options={{
+          headerShown: false,
+        }}
+      />
+      <ProfileStack.Screen
+        name="ListenedAlbums"
+        component={ListenedAlbumsScreen}
+        options={{
+          headerShown: false,
+        }}
+      />
+      <ProfileStack.Screen
+        name="UserReviews"
+        component={UserReviewsScreen}
         options={{
           headerShown: false,
         }}

--- a/Musicboxd/src/navigation/AppNavigator.tsx
+++ b/Musicboxd/src/navigation/AppNavigator.tsx
@@ -185,6 +185,13 @@ function ProfileStackNavigator() {
         options={{ title: 'Profile' }}
       />
       <ProfileStack.Screen
+        name="AlbumDetails"
+        component={AlbumDetailsScreen}
+        options={{
+          title: 'Album Details',
+        }}
+      />
+      <ProfileStack.Screen
         name="UserProfile"
         component={UserProfileScreen}
         options={{

--- a/Musicboxd/src/screens/Album/AlbumDetailsScreen.tsx
+++ b/Musicboxd/src/screens/Album/AlbumDetailsScreen.tsx
@@ -25,7 +25,8 @@ import {
   clearCurrentAlbum, 
   setCurrentAlbumUserReview, 
   setCurrentAlbumIsListened,
-  addListen 
+  addListen,
+  removeListen
 } from '../../store/slices/albumSlice';
 import { AlbumService } from '../../services/albumService';
 import { theme, spacing, shadows } from '../../utils/theme';
@@ -156,6 +157,7 @@ export default function AlbumDetailsScreen() {
         const response = await AlbumService.removeListened(user.id, currentAlbum.id);
         if (response.success) {
           dispatch(setCurrentAlbumIsListened(false));
+          dispatch(removeListen({ userId: user.id, albumId: currentAlbum.id }));
         }
       } else {
         // Add listen

--- a/Musicboxd/src/screens/Home/HomeScreen.tsx
+++ b/Musicboxd/src/screens/Home/HomeScreen.tsx
@@ -43,11 +43,6 @@ export default function HomeScreen() {
     }
   }, [currentUser]);
 
-  useEffect(() => {
-    loadPopularAlbums();
-    loadSuggestedUsers();
-  }, [loadSuggestedUsers, loadPopularAlbums]);
-
   const loadPopularAlbums = useCallback(async () => {
     dispatch(fetchAlbumsStart());
     try {
@@ -60,6 +55,11 @@ export default function HomeScreen() {
       console.error('Error loading albums:', error);
     }
   }, [dispatch]);
+
+  useEffect(() => {
+    loadPopularAlbums();
+    loadSuggestedUsers();
+  }, [loadSuggestedUsers, loadPopularAlbums]);
 
   const navigateToAlbum = (albumId: string) => {
     navigation.navigate('AlbumDetails', { albumId });
@@ -128,7 +128,7 @@ export default function HomeScreen() {
 
       <ScrollView horizontal showsHorizontalScrollIndicator={false}>
         <View style={styles.albumGrid}>
-          {popularAlbums.map((album, index) => renderAlbumCard(album, index))}
+          {popularAlbums.map((album) => renderAlbumCard(album))}
         </View>
       </ScrollView>
 
@@ -142,7 +142,7 @@ export default function HomeScreen() {
         
         <ScrollView horizontal showsHorizontalScrollIndicator={false}>
           <View style={styles.userGrid}>
-            {suggestedUsers.map((user, index) => renderUserCard(user, index))}
+            {suggestedUsers.map((user) => renderUserCard(user))}
           </View>
         </ScrollView>
       </View>

--- a/Musicboxd/src/screens/Profile/FollowersScreen.tsx
+++ b/Musicboxd/src/screens/Profile/FollowersScreen.tsx
@@ -51,10 +51,6 @@ export default function FollowersScreen() {
   const [followingUsers, setFollowingUsers] = useState<User[]>([]);
   const [loading, setLoading] = useState(true);
 
-  useEffect(() => {
-    loadData();
-  }, [userId, activeTab, loadData]);
-
   const loadData = useCallback(async () => {
     setLoading(true);
     try {
@@ -71,6 +67,10 @@ export default function FollowersScreen() {
       setLoading(false);
     }
   }, [userId, activeTab]);
+
+  useEffect(() => {
+    loadData();
+  }, [loadData]);
 
   const isFollowing = (targetUserId: string) => {
     return following.some(user => user.id === targetUserId);

--- a/Musicboxd/src/screens/Profile/FollowersScreen.tsx
+++ b/Musicboxd/src/screens/Profile/FollowersScreen.tsx
@@ -70,7 +70,7 @@ export default function FollowersScreen() {
 
   useEffect(() => {
     loadData();
-  }, [loadData]);
+  }, [userId, activeTab, loadData]);
 
   const isFollowing = (targetUserId: string) => {
     return following.some(user => user.id === targetUserId);

--- a/Musicboxd/src/screens/Profile/ListenedAlbumsScreen.tsx
+++ b/Musicboxd/src/screens/Profile/ListenedAlbumsScreen.tsx
@@ -26,7 +26,7 @@ type ListenedAlbumsScreenRouteProp = RouteProp<
   'ListenedAlbums'
 >;
 type ListenedAlbumsScreenNavigationProp = StackNavigationProp<
-  HomeStackParamList | SearchStackParamList | ProfileStackParamList
+  HomeStackParamList & SearchStackParamList & ProfileStackParamList
 >;
 
 const { width } = Dimensions.get('window');
@@ -79,7 +79,7 @@ export default function ListenedAlbumsScreen() {
   }, [loadListenedAlbums]);
 
   const navigateToAlbum = (albumId: string) => {
-    (navigation as any).navigate('AlbumDetails', { albumId });
+    navigation.navigate('AlbumDetails', { albumId });
   };
 
   const formatListenDate = (date: Date) => {

--- a/Musicboxd/src/screens/Profile/ListenedAlbumsScreen.tsx
+++ b/Musicboxd/src/screens/Profile/ListenedAlbumsScreen.tsx
@@ -14,10 +14,12 @@ import {
 } from 'react-native-paper';
 import { RouteProp, useRoute, useNavigation } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
+import { useSelector } from 'react-redux';
 
 import { theme, spacing, shadows } from '../../utils/theme';
 import { Listen, Album, HomeStackParamList, SearchStackParamList, ProfileStackParamList } from '../../types';
 import { AlbumService } from '../../services/albumService';
+import { RootState } from '../../store';
 
 type ListenedAlbumsScreenRouteProp = RouteProp<
   HomeStackParamList | SearchStackParamList | ProfileStackParamList,
@@ -39,6 +41,7 @@ export default function ListenedAlbumsScreen() {
   const route = useRoute<ListenedAlbumsScreenRouteProp>();
   const navigation = useNavigation<ListenedAlbumsScreenNavigationProp>();
   const { userId, username } = route.params;
+  const { user: currentUser } = useSelector((state: RootState) => state.auth);
 
   const [listenedAlbums, setListenedAlbums] = useState<ListenedAlbumData[]>([]);
   const [loading, setLoading] = useState(true);
@@ -147,7 +150,7 @@ export default function ListenedAlbumsScreen() {
             No Albums Yet
           </Text>
           <Text variant="bodyMedium" style={styles.emptyText}>
-            {username === 'you' ? 'Start listening to albums and they\'ll appear here!' : `${username} hasn't listened to any albums yet.`}
+            {userId === currentUser?.id ? 'Start listening to albums and they\'ll appear here!' : `${username} hasn't listened to any albums yet.`}
           </Text>
         </View>
       ) : (

--- a/Musicboxd/src/screens/Profile/ListenedAlbumsScreen.tsx
+++ b/Musicboxd/src/screens/Profile/ListenedAlbumsScreen.tsx
@@ -107,11 +107,6 @@ export default function ListenedAlbumsScreen() {
         <Text variant="bodySmall" style={styles.listenDate}>
           {formatListenDate(new Date(data.listen.dateListened))}
         </Text>
-        {data.listen.notes && (
-          <Text variant="bodySmall" numberOfLines={2} style={styles.notes}>
-            "{data.listen.notes}"
-          </Text>
-        )}
       </View>
     </TouchableOpacity>
   );
@@ -242,12 +237,6 @@ const styles = StyleSheet.create({
     color: theme.colors.primary,
     fontSize: 12,
     fontWeight: '500',
-    marginBottom: spacing.xs,
-  },
-  notes: {
-    color: theme.colors.textSecondary,
-    fontStyle: 'italic',
-    fontSize: 12,
   },
   emptyContainer: {
     flex: 1,

--- a/Musicboxd/src/screens/Profile/ListenedAlbumsScreen.tsx
+++ b/Musicboxd/src/screens/Profile/ListenedAlbumsScreen.tsx
@@ -25,9 +25,7 @@ type ListenedAlbumsScreenRouteProp = RouteProp<
   HomeStackParamList | SearchStackParamList | ProfileStackParamList,
   'ListenedAlbums'
 >;
-type ListenedAlbumsScreenNavigationProp = StackNavigationProp<
-  HomeStackParamList & SearchStackParamList & ProfileStackParamList
->;
+type ListenedAlbumsScreenNavigationProp = StackNavigationProp<ProfileStackParamList>;
 
 const { width } = Dimensions.get('window');
 const ALBUM_CARD_WIDTH = (width - spacing.lg * 3) / 2;

--- a/Musicboxd/src/screens/Profile/ListenedAlbumsScreen.tsx
+++ b/Musicboxd/src/screens/Profile/ListenedAlbumsScreen.tsx
@@ -1,0 +1,271 @@
+import React, { useEffect, useState, useCallback } from 'react';
+import {
+  View,
+  ScrollView,
+  StyleSheet,
+  TouchableOpacity,
+  Image,
+  Dimensions,
+} from 'react-native';
+import {
+  Text,
+  ActivityIndicator,
+  IconButton,
+} from 'react-native-paper';
+import { RouteProp, useRoute, useNavigation } from '@react-navigation/native';
+import { StackNavigationProp } from '@react-navigation/stack';
+
+import { theme, spacing, shadows } from '../../utils/theme';
+import { Listen, Album, HomeStackParamList, SearchStackParamList, ProfileStackParamList } from '../../types';
+import { AlbumService } from '../../services/albumService';
+
+type ListenedAlbumsScreenRouteProp = RouteProp<
+  HomeStackParamList | SearchStackParamList | ProfileStackParamList,
+  'ListenedAlbums'
+>;
+type ListenedAlbumsScreenNavigationProp = StackNavigationProp<
+  HomeStackParamList | SearchStackParamList | ProfileStackParamList
+>;
+
+const { width } = Dimensions.get('window');
+const ALBUM_CARD_WIDTH = (width - spacing.lg * 3) / 2;
+
+interface ListenedAlbumData {
+  listen: Listen;
+  album: Album;
+}
+
+export default function ListenedAlbumsScreen() {
+  const route = useRoute<ListenedAlbumsScreenRouteProp>();
+  const navigation = useNavigation<ListenedAlbumsScreenNavigationProp>();
+  const { userId, username } = route.params;
+
+  const [listenedAlbums, setListenedAlbums] = useState<ListenedAlbumData[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const loadListenedAlbums = useCallback(async () => {
+    setLoading(true);
+    try {
+      const listens = await AlbumService.getUserListens(userId);
+      
+      // Get album details for each listen
+      const albumPromises = listens.map(async (listen) => {
+        const albumResponse = await AlbumService.getAlbumById(listen.albumId);
+        return {
+          listen,
+          album: albumResponse.data!,
+        };
+      });
+
+      const albumsData = await Promise.all(albumPromises);
+      // Filter out any failed album fetches and sort by listen date (newest first)
+      const validAlbums = albumsData
+        .filter(data => data.album)
+        .sort((a, b) => new Date(b.listen.dateListened).getTime() - new Date(a.listen.dateListened).getTime());
+      
+      setListenedAlbums(validAlbums);
+    } catch (error) {
+      console.error('Error loading listened albums:', error);
+    } finally {
+      setLoading(false);
+    }
+  }, [userId]);
+
+  useEffect(() => {
+    loadListenedAlbums();
+  }, [loadListenedAlbums]);
+
+  const navigateToAlbum = (albumId: string) => {
+    (navigation as any).navigate('AlbumDetails', { albumId });
+  };
+
+  const formatListenDate = (date: Date) => {
+    const now = new Date();
+    const diffInDays = Math.floor((now.getTime() - date.getTime()) / (1000 * 60 * 60 * 24));
+    
+    if (diffInDays === 0) return 'Today';
+    if (diffInDays === 1) return 'Yesterday';
+    if (diffInDays < 7) return `${diffInDays} days ago`;
+    if (diffInDays < 30) return `${Math.floor(diffInDays / 7)} weeks ago`;
+    return date.toLocaleDateString();
+  };
+
+  const renderAlbumCard = (data: ListenedAlbumData) => (
+    <TouchableOpacity
+      key={data.listen.id}
+      style={styles.albumCard}
+      onPress={() => navigateToAlbum(data.album.id)}
+    >
+      <Image source={{ uri: data.album.coverImageUrl }} style={styles.albumCover} />
+      <View style={styles.albumInfo}>
+        <Text variant="bodyMedium" numberOfLines={2} style={styles.albumTitle}>
+          {data.album.title}
+        </Text>
+        <Text variant="bodySmall" numberOfLines={1} style={styles.artistName}>
+          {data.album.artist}
+        </Text>
+        <Text variant="bodySmall" style={styles.listenDate}>
+          {formatListenDate(new Date(data.listen.dateListened))}
+        </Text>
+        {data.listen.notes && (
+          <Text variant="bodySmall" numberOfLines={2} style={styles.notes}>
+            "{data.listen.notes}"
+          </Text>
+        )}
+      </View>
+    </TouchableOpacity>
+  );
+
+  if (loading) {
+    return (
+      <View style={styles.centerContainer}>
+        <ActivityIndicator size="large" />
+        <Text variant="bodyLarge" style={styles.loadingText}>
+          Loading listened albums...
+        </Text>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      {/* Header */}
+      <View style={styles.header}>
+        <IconButton
+          icon="arrow-left"
+          onPress={() => navigation.goBack()}
+          style={styles.backButton}
+        />
+        <View style={styles.headerContent}>
+          <Text variant="headlineSmall" style={styles.headerTitle}>
+            Albums Listened
+          </Text>
+          <Text variant="bodyMedium" style={styles.headerSubtitle}>
+            @{username} • {listenedAlbums.length} album{listenedAlbums.length !== 1 ? 's' : ''}
+          </Text>
+        </View>
+      </View>
+
+      {listenedAlbums.length === 0 ? (
+        <View style={styles.emptyContainer}>
+          <Text variant="titleLarge" style={styles.emptyTitle}>
+            No Albums Yet
+          </Text>
+          <Text variant="bodyMedium" style={styles.emptyText}>
+            {username === 'you' ? 'Start listening to albums and they\'ll appear here!' : `${username} hasn't listened to any albums yet.`}
+          </Text>
+        </View>
+      ) : (
+        <ScrollView style={styles.scrollView} showsVerticalScrollIndicator={false}>
+          <View style={styles.albumGrid}>
+            {listenedAlbums.map(renderAlbumCard)}
+          </View>
+          <View style={styles.bottomPadding} />
+        </ScrollView>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: theme.colors.background,
+  },
+  centerContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: theme.colors.background,
+  },
+  loadingText: {
+    marginTop: spacing.md,
+    color: theme.colors.textSecondary,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    padding: spacing.lg,
+    backgroundColor: theme.colors.surface,
+    borderBottomWidth: 1,
+    borderBottomColor: theme.colors.border,
+  },
+  backButton: {
+    margin: 0,
+  },
+  headerContent: {
+    flex: 1,
+    marginLeft: spacing.sm,
+  },
+  headerTitle: {
+    fontWeight: 'bold',
+  },
+  headerSubtitle: {
+    color: theme.colors.textSecondary,
+    marginTop: spacing.xs,
+  },
+  scrollView: {
+    flex: 1,
+  },
+  albumGrid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    padding: spacing.lg,
+    justifyContent: 'space-between',
+  },
+  albumCard: {
+    width: ALBUM_CARD_WIDTH,
+    backgroundColor: theme.colors.surface,
+    borderRadius: 12,
+    marginBottom: spacing.lg,
+    ...shadows.small,
+  },
+  albumCover: {
+    width: '100%',
+    aspectRatio: 1,
+    borderTopLeftRadius: 12,
+    borderTopRightRadius: 12,
+    resizeMode: 'cover',
+  },
+  albumInfo: {
+    padding: spacing.md,
+  },
+  albumTitle: {
+    fontWeight: '600',
+    marginBottom: spacing.xs,
+  },
+  artistName: {
+    color: theme.colors.textSecondary,
+    marginBottom: spacing.xs,
+  },
+  listenDate: {
+    color: theme.colors.primary,
+    fontSize: 12,
+    fontWeight: '500',
+    marginBottom: spacing.xs,
+  },
+  notes: {
+    color: theme.colors.textSecondary,
+    fontStyle: 'italic',
+    fontSize: 12,
+  },
+  emptyContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: spacing.xl,
+  },
+  emptyTitle: {
+    fontWeight: 'bold',
+    marginBottom: spacing.md,
+    textAlign: 'center',
+  },
+  emptyText: {
+    color: theme.colors.textSecondary,
+    textAlign: 'center',
+    lineHeight: 22,
+  },
+  bottomPadding: {
+    height: spacing.xl,
+  },
+});

--- a/Musicboxd/src/screens/Profile/ProfileScreen.tsx
+++ b/Musicboxd/src/screens/Profile/ProfileScreen.tsx
@@ -150,9 +150,9 @@ export default function ProfileScreen() {
                 <Text variant="headlineMedium" style={styles.statNumber}>
                   {stats.reviews}
                 </Text>
-                <Text variant="bodySmall" style={styles.statLabel}>
-                  Reviews
-                </Text>
+                               <Text variant="bodySmall" style={styles.statLabel}>
+                 Ratings
+               </Text>
               </Card.Content>
             </Card>
           </TouchableOpacity>

--- a/Musicboxd/src/screens/Profile/ProfileScreen.tsx
+++ b/Musicboxd/src/screens/Profile/ProfileScreen.tsx
@@ -118,10 +118,11 @@ export default function ProfileScreen() {
         </Text>
       </View>
 
-      {/* Stats Cards */}
+            {/* Stats Grid */}
       <View style={styles.statsContainer}>
-        <View style={styles.statsRow}>
+        <View style={styles.statsGrid}>
           <TouchableOpacity
+            style={styles.statCardWrapper}
             onPress={() => navigation.navigate('ListenedAlbums', { 
               userId: user.id, 
               username: user.username 
@@ -140,6 +141,7 @@ export default function ProfileScreen() {
           </TouchableOpacity>
           
           <TouchableOpacity
+            style={styles.statCardWrapper}
             onPress={() => navigation.navigate('UserReviews', { 
               userId: user.id, 
               username: user.username 
@@ -150,31 +152,28 @@ export default function ProfileScreen() {
                 <Text variant="headlineMedium" style={styles.statNumber}>
                   {stats.reviews}
                 </Text>
-                               <Text variant="bodySmall" style={styles.statLabel}>
-                 Ratings
-               </Text>
+                <Text variant="bodySmall" style={styles.statLabel}>
+                  Ratings
+                </Text>
               </Card.Content>
             </Card>
           </TouchableOpacity>
-        </View>
 
-        <View style={styles.statsRow}>
-          <Card style={styles.statCard} elevation={1}>
-            <Card.Content style={styles.statContent}>
-              <Text variant="headlineMedium" style={styles.statNumber}>
-                {stats.averageRating > 0 ? `${stats.averageRating}★` : '—'}
-              </Text>
-              <Text variant="bodySmall" style={styles.statLabel}>
-                Average Rating
-              </Text>
-            </Card.Content>
-          </Card>
-          
-          <View style={styles.statCard} />
-        </View>
+          <View style={styles.statCardWrapper}>
+            <Card style={styles.statCard} elevation={1}>
+              <Card.Content style={styles.statContent}>
+                <Text variant="headlineMedium" style={styles.statNumber}>
+                  {stats.averageRating > 0 ? `${stats.averageRating}★` : '—'}
+                </Text>
+                <Text variant="bodySmall" style={styles.statLabel}>
+                  Average Rating
+                </Text>
+              </Card.Content>
+            </Card>
+          </View>
 
-        <View style={styles.statsRow}>
           <TouchableOpacity
+            style={styles.statCardWrapper}
             onPress={() => navigation.navigate('Followers', { 
               userId: user.id, 
               username: user.username,
@@ -194,6 +193,7 @@ export default function ProfileScreen() {
           </TouchableOpacity>
           
           <TouchableOpacity
+            style={styles.statCardWrapper}
             onPress={() => navigation.navigate('Followers', { 
               userId: user.id, 
               username: user.username,
@@ -211,6 +211,9 @@ export default function ProfileScreen() {
               </Card.Content>
             </Card>
           </TouchableOpacity>
+
+          {/* Empty placeholder to maintain grid alignment */}
+          <View style={styles.statCardWrapper} />
         </View>
       </View>
 
@@ -322,13 +325,17 @@ const styles = StyleSheet.create({
   statsContainer: {
     padding: spacing.lg,
   },
-  statsRow: {
+  statsGrid: {
     flexDirection: 'row',
+    flexWrap: 'wrap',
+    justifyContent: 'space-between',
+  },
+  statCardWrapper: {
+    width: '48%',
     marginBottom: spacing.md,
   },
   statCard: {
     flex: 1,
-    marginHorizontal: spacing.xs,
     backgroundColor: theme.colors.surface,
   },
   statContent: {

--- a/Musicboxd/src/screens/Profile/ProfileScreen.tsx
+++ b/Musicboxd/src/screens/Profile/ProfileScreen.tsx
@@ -40,10 +40,12 @@ export default function ProfileScreen() {
   const navigation = useNavigation<ProfileScreenNavigationProp>();
   const { user, isAuthenticated } = useSelector((state: RootState) => state.auth);
   const { following } = useSelector((state: RootState) => state.user);
+  const { userListens, userReviews } = useSelector((state: RootState) => state.albums);
   
   const [stats, setStats] = useState({
-    albumsListened: 127,
-    reviews: 23,
+    albumsListened: 0,
+    reviews: 0,
+    averageRating: 0,
     following: 0,
     followers: 0,
   });
@@ -90,7 +92,7 @@ export default function ProfileScreen() {
     };
     
     loadStats();
-  }, [user, following]); // Reload when following state changes
+  }, [user, following, userListens, userReviews]); // Reload when following state or user interactions change
 
   if (!user) {
     return null; // or loading spinner
@@ -140,6 +142,21 @@ export default function ProfileScreen() {
               </Text>
             </Card.Content>
           </Card>
+        </View>
+
+        <View style={styles.statsRow}>
+          <Card style={styles.statCard} elevation={1}>
+            <Card.Content style={styles.statContent}>
+              <Text variant="headlineMedium" style={styles.statNumber}>
+                {stats.averageRating > 0 ? `${stats.averageRating}★` : '—'}
+              </Text>
+              <Text variant="bodySmall" style={styles.statLabel}>
+                Average Rating
+              </Text>
+            </Card.Content>
+          </Card>
+          
+          <View style={styles.statCard} />
         </View>
 
         <View style={styles.statsRow}>

--- a/Musicboxd/src/screens/Profile/ProfileScreen.tsx
+++ b/Musicboxd/src/screens/Profile/ProfileScreen.tsx
@@ -159,19 +159,6 @@ export default function ProfileScreen() {
             </Card>
           </TouchableOpacity>
 
-          <View style={styles.statCardWrapper}>
-            <Card style={styles.statCard} elevation={1}>
-              <Card.Content style={styles.statContent}>
-                <Text variant="headlineMedium" style={styles.statNumber}>
-                  {stats.averageRating > 0 ? `${stats.averageRating}★` : '—'}
-                </Text>
-                <Text variant="bodySmall" style={styles.statLabel}>
-                  Average Rating
-                </Text>
-              </Card.Content>
-            </Card>
-          </View>
-
           <TouchableOpacity
             style={styles.statCardWrapper}
             onPress={() => navigation.navigate('Followers', { 
@@ -211,9 +198,6 @@ export default function ProfileScreen() {
               </Card.Content>
             </Card>
           </TouchableOpacity>
-
-          {/* Empty placeholder to maintain grid alignment */}
-          <View style={styles.statCardWrapper} />
         </View>
       </View>
 

--- a/Musicboxd/src/screens/Profile/ProfileScreen.tsx
+++ b/Musicboxd/src/screens/Profile/ProfileScreen.tsx
@@ -121,27 +121,41 @@ export default function ProfileScreen() {
       {/* Stats Cards */}
       <View style={styles.statsContainer}>
         <View style={styles.statsRow}>
-          <Card style={styles.statCard} elevation={1}>
-            <Card.Content style={styles.statContent}>
-              <Text variant="headlineMedium" style={styles.statNumber}>
-                {stats.albumsListened}
-              </Text>
-              <Text variant="bodySmall" style={styles.statLabel}>
-                Albums Listened
-              </Text>
-            </Card.Content>
-          </Card>
+          <TouchableOpacity
+            onPress={() => navigation.navigate('ListenedAlbums', { 
+              userId: user.id, 
+              username: user.username 
+            })}
+          >
+            <Card style={styles.statCard} elevation={1}>
+              <Card.Content style={styles.statContent}>
+                <Text variant="headlineMedium" style={styles.statNumber}>
+                  {stats.albumsListened}
+                </Text>
+                <Text variant="bodySmall" style={styles.statLabel}>
+                  Albums Listened
+                </Text>
+              </Card.Content>
+            </Card>
+          </TouchableOpacity>
           
-          <Card style={styles.statCard} elevation={1}>
-            <Card.Content style={styles.statContent}>
-              <Text variant="headlineMedium" style={styles.statNumber}>
-                {stats.reviews}
-              </Text>
-              <Text variant="bodySmall" style={styles.statLabel}>
-                Reviews
-              </Text>
-            </Card.Content>
-          </Card>
+          <TouchableOpacity
+            onPress={() => navigation.navigate('UserReviews', { 
+              userId: user.id, 
+              username: user.username 
+            })}
+          >
+            <Card style={styles.statCard} elevation={1}>
+              <Card.Content style={styles.statContent}>
+                <Text variant="headlineMedium" style={styles.statNumber}>
+                  {stats.reviews}
+                </Text>
+                <Text variant="bodySmall" style={styles.statLabel}>
+                  Reviews
+                </Text>
+              </Card.Content>
+            </Card>
+          </TouchableOpacity>
         </View>
 
         <View style={styles.statsRow}>

--- a/Musicboxd/src/screens/Profile/UserProfileScreen.tsx
+++ b/Musicboxd/src/screens/Profile/UserProfileScreen.tsx
@@ -48,10 +48,6 @@ export default function UserProfileScreen() {
   const isFollowing = following.some(followedUser => followedUser.id === userId);
   const isOwnProfile = currentUser?.id === userId;
 
-  useEffect(() => {
-    loadUserProfile();
-  }, [userId, following, loadUserProfile]); // Reload when following state changes
-
   const loadUserProfile = useCallback(async () => {
     setLoading(true);
     try {
@@ -68,6 +64,10 @@ export default function UserProfileScreen() {
       setLoading(false);
     }
   }, [userId]);
+
+  useEffect(() => {
+    loadUserProfile();
+  }, [loadUserProfile]); // Reload when following state changes
 
   const handleFollowToggle = async () => {
     if (!user) return;
@@ -213,6 +213,21 @@ export default function UserProfileScreen() {
               </Text>
             </Card.Content>
           </Card>
+        </View>
+
+        <View style={styles.statsRow}>
+          <Card style={styles.statCard} elevation={1}>
+            <Card.Content style={styles.statContent}>
+              <Text variant="headlineMedium" style={styles.statNumber}>
+                {userStats.averageRating > 0 ? `${userStats.averageRating}★` : '—'}
+              </Text>
+              <Text variant="bodySmall" style={styles.statLabel}>
+                Average Rating
+              </Text>
+            </Card.Content>
+          </Card>
+          
+          <View style={styles.statCard} />
         </View>
 
         <View style={styles.statsRow}>

--- a/Musicboxd/src/screens/Profile/UserProfileScreen.tsx
+++ b/Musicboxd/src/screens/Profile/UserProfileScreen.tsx
@@ -230,19 +230,6 @@ export default function UserProfileScreen() {
             </Card>
           </TouchableOpacity>
 
-          <View style={styles.statCardWrapper}>
-            <Card style={styles.statCard} elevation={1}>
-              <Card.Content style={styles.statContent}>
-                <Text variant="headlineMedium" style={styles.statNumber}>
-                  {userStats.averageRating > 0 ? `${userStats.averageRating}★` : '—'}
-                </Text>
-                <Text variant="bodySmall" style={styles.statLabel}>
-                  Average Rating
-                </Text>
-              </Card.Content>
-            </Card>
-          </View>
-
           <TouchableOpacity
             style={styles.statCardWrapper}
             onPress={() => navigation.navigate('Followers', { 
@@ -282,9 +269,6 @@ export default function UserProfileScreen() {
               </Card.Content>
             </Card>
           </TouchableOpacity>
-
-          {/* Empty placeholder to maintain grid alignment */}
-          <View style={styles.statCardWrapper} />
         </View>
       </View>
 

--- a/Musicboxd/src/screens/Profile/UserProfileScreen.tsx
+++ b/Musicboxd/src/screens/Profile/UserProfileScreen.tsx
@@ -221,9 +221,9 @@ export default function UserProfileScreen() {
                 <Text variant="headlineMedium" style={styles.statNumber}>
                   {userStats.reviews}
                 </Text>
-                <Text variant="bodySmall" style={styles.statLabel}>
-                  Reviews
-                </Text>
+                               <Text variant="bodySmall" style={styles.statLabel}>
+                 Ratings
+               </Text>
               </Card.Content>
             </Card>
           </TouchableOpacity>

--- a/Musicboxd/src/screens/Profile/UserProfileScreen.tsx
+++ b/Musicboxd/src/screens/Profile/UserProfileScreen.tsx
@@ -189,10 +189,11 @@ export default function UserProfileScreen() {
         )}
       </View>
 
-      {/* Stats Cards */}
+            {/* Stats Grid */}
       <View style={styles.statsContainer}>
-        <View style={styles.statsRow}>
+        <View style={styles.statsGrid}>
           <TouchableOpacity
+            style={styles.statCardWrapper}
             onPress={() => navigation.navigate('ListenedAlbums', { 
               userId: user.id, 
               username: user.username 
@@ -211,6 +212,7 @@ export default function UserProfileScreen() {
           </TouchableOpacity>
           
           <TouchableOpacity
+            style={styles.statCardWrapper}
             onPress={() => navigation.navigate('UserReviews', { 
               userId: user.id, 
               username: user.username 
@@ -221,31 +223,28 @@ export default function UserProfileScreen() {
                 <Text variant="headlineMedium" style={styles.statNumber}>
                   {userStats.reviews}
                 </Text>
-                               <Text variant="bodySmall" style={styles.statLabel}>
-                 Ratings
-               </Text>
+                <Text variant="bodySmall" style={styles.statLabel}>
+                  Ratings
+                </Text>
               </Card.Content>
             </Card>
           </TouchableOpacity>
-        </View>
 
-        <View style={styles.statsRow}>
-          <Card style={styles.statCard} elevation={1}>
-            <Card.Content style={styles.statContent}>
-              <Text variant="headlineMedium" style={styles.statNumber}>
-                {userStats.averageRating > 0 ? `${userStats.averageRating}★` : '—'}
-              </Text>
-              <Text variant="bodySmall" style={styles.statLabel}>
-                Average Rating
-              </Text>
-            </Card.Content>
-          </Card>
-          
-          <View style={styles.statCard} />
-        </View>
+          <View style={styles.statCardWrapper}>
+            <Card style={styles.statCard} elevation={1}>
+              <Card.Content style={styles.statContent}>
+                <Text variant="headlineMedium" style={styles.statNumber}>
+                  {userStats.averageRating > 0 ? `${userStats.averageRating}★` : '—'}
+                </Text>
+                <Text variant="bodySmall" style={styles.statLabel}>
+                  Average Rating
+                </Text>
+              </Card.Content>
+            </Card>
+          </View>
 
-        <View style={styles.statsRow}>
           <TouchableOpacity
+            style={styles.statCardWrapper}
             onPress={() => navigation.navigate('Followers', { 
               userId: user.id, 
               username: user.username,
@@ -265,6 +264,7 @@ export default function UserProfileScreen() {
           </TouchableOpacity>
           
           <TouchableOpacity
+            style={styles.statCardWrapper}
             onPress={() => navigation.navigate('Followers', { 
               userId: user.id, 
               username: user.username,
@@ -282,6 +282,9 @@ export default function UserProfileScreen() {
               </Card.Content>
             </Card>
           </TouchableOpacity>
+
+          {/* Empty placeholder to maintain grid alignment */}
+          <View style={styles.statCardWrapper} />
         </View>
       </View>
 
@@ -377,13 +380,17 @@ const styles = StyleSheet.create({
   statsContainer: {
     padding: spacing.lg,
   },
-  statsRow: {
+  statsGrid: {
     flexDirection: 'row',
+    flexWrap: 'wrap',
+    justifyContent: 'space-between',
+  },
+  statCardWrapper: {
+    width: '48%',
     marginBottom: spacing.md,
   },
   statCard: {
     flex: 1,
-    marginHorizontal: spacing.xs,
     backgroundColor: theme.colors.surface,
   },
   statContent: {

--- a/Musicboxd/src/screens/Profile/UserProfileScreen.tsx
+++ b/Musicboxd/src/screens/Profile/UserProfileScreen.tsx
@@ -192,27 +192,41 @@ export default function UserProfileScreen() {
       {/* Stats Cards */}
       <View style={styles.statsContainer}>
         <View style={styles.statsRow}>
-          <Card style={styles.statCard} elevation={1}>
-            <Card.Content style={styles.statContent}>
-              <Text variant="headlineMedium" style={styles.statNumber}>
-                {userStats.albumsListened}
-              </Text>
-              <Text variant="bodySmall" style={styles.statLabel}>
-                Albums Listened
-              </Text>
-            </Card.Content>
-          </Card>
+          <TouchableOpacity
+            onPress={() => navigation.navigate('ListenedAlbums', { 
+              userId: user.id, 
+              username: user.username 
+            })}
+          >
+            <Card style={styles.statCard} elevation={1}>
+              <Card.Content style={styles.statContent}>
+                <Text variant="headlineMedium" style={styles.statNumber}>
+                  {userStats.albumsListened}
+                </Text>
+                <Text variant="bodySmall" style={styles.statLabel}>
+                  Albums Listened
+                </Text>
+              </Card.Content>
+            </Card>
+          </TouchableOpacity>
           
-          <Card style={styles.statCard} elevation={1}>
-            <Card.Content style={styles.statContent}>
-              <Text variant="headlineMedium" style={styles.statNumber}>
-                {userStats.reviews}
-              </Text>
-              <Text variant="bodySmall" style={styles.statLabel}>
-                Reviews
-              </Text>
-            </Card.Content>
-          </Card>
+          <TouchableOpacity
+            onPress={() => navigation.navigate('UserReviews', { 
+              userId: user.id, 
+              username: user.username 
+            })}
+          >
+            <Card style={styles.statCard} elevation={1}>
+              <Card.Content style={styles.statContent}>
+                <Text variant="headlineMedium" style={styles.statNumber}>
+                  {userStats.reviews}
+                </Text>
+                <Text variant="bodySmall" style={styles.statLabel}>
+                  Reviews
+                </Text>
+              </Card.Content>
+            </Card>
+          </TouchableOpacity>
         </View>
 
         <View style={styles.statsRow}>

--- a/Musicboxd/src/screens/Profile/UserProfileScreen.tsx
+++ b/Musicboxd/src/screens/Profile/UserProfileScreen.tsx
@@ -67,7 +67,7 @@ export default function UserProfileScreen() {
 
   useEffect(() => {
     loadUserProfile();
-  }, [loadUserProfile]); // Reload when following state changes
+  }, [userId, following, loadUserProfile]); // Reload when userId changes, following state changes, or loadUserProfile changes
 
   const handleFollowToggle = async () => {
     if (!user) return;

--- a/Musicboxd/src/screens/Profile/UserReviewsScreen.tsx
+++ b/Musicboxd/src/screens/Profile/UserReviewsScreen.tsx
@@ -1,0 +1,343 @@
+import React, { useEffect, useState, useCallback } from 'react';
+import {
+  View,
+  ScrollView,
+  StyleSheet,
+  TouchableOpacity,
+  Image,
+} from 'react-native';
+import {
+  Text,
+  ActivityIndicator,
+  IconButton,
+} from 'react-native-paper';
+import { RouteProp, useRoute, useNavigation } from '@react-navigation/native';
+import { StackNavigationProp } from '@react-navigation/stack';
+
+import { theme, spacing, shadows } from '../../utils/theme';
+import { Review, Album, HomeStackParamList, SearchStackParamList, ProfileStackParamList } from '../../types';
+import { AlbumService } from '../../services/albumService';
+
+type UserReviewsScreenRouteProp = RouteProp<
+  HomeStackParamList | SearchStackParamList | ProfileStackParamList,
+  'UserReviews'
+>;
+type UserReviewsScreenNavigationProp = StackNavigationProp<
+  HomeStackParamList | SearchStackParamList | ProfileStackParamList
+>;
+
+
+
+interface ReviewData {
+  review: Review;
+  album: Album;
+}
+
+const StarDisplay = ({ rating }: { rating: number }) => (
+  <View style={styles.starContainer}>
+    {[1, 2, 3, 4, 5].map((star) => (
+      <Text
+        key={star}
+        style={[
+          styles.star,
+          star <= rating ? styles.starFilled : styles.starEmpty
+        ]}
+      >
+        {star <= rating ? '★' : '☆'}
+      </Text>
+    ))}
+  </View>
+);
+
+export default function UserReviewsScreen() {
+  const route = useRoute<UserReviewsScreenRouteProp>();
+  const navigation = useNavigation<UserReviewsScreenNavigationProp>();
+  const { userId, username } = route.params;
+
+  const [reviews, setReviews] = useState<ReviewData[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const loadUserReviews = useCallback(async () => {
+    setLoading(true);
+    try {
+      const userReviews = await AlbumService.getUserReviews(userId);
+      
+      // Get album details for each review
+      const albumPromises = userReviews.map(async (review) => {
+        const albumResponse = await AlbumService.getAlbumById(review.albumId);
+        return {
+          review,
+          album: albumResponse.data!,
+        };
+      });
+
+      const reviewsData = await Promise.all(albumPromises);
+      // Filter out any failed album fetches and sort by review date (newest first)
+      const validReviews = reviewsData
+        .filter(data => data.album)
+        .sort((a, b) => new Date(b.review.dateReviewed).getTime() - new Date(a.review.dateReviewed).getTime());
+      
+      setReviews(validReviews);
+    } catch (error) {
+      console.error('Error loading user reviews:', error);
+    } finally {
+      setLoading(false);
+    }
+  }, [userId]);
+
+  useEffect(() => {
+    loadUserReviews();
+  }, [loadUserReviews]);
+
+  const navigateToAlbum = (albumId: string) => {
+    (navigation as any).navigate('AlbumDetails', { albumId });
+  };
+
+  const formatReviewDate = (date: Date) => {
+    const now = new Date();
+    const diffInDays = Math.floor((now.getTime() - date.getTime()) / (1000 * 60 * 60 * 24));
+    
+    if (diffInDays === 0) return 'Today';
+    if (diffInDays === 1) return 'Yesterday';
+    if (diffInDays < 7) return `${diffInDays} days ago`;
+    if (diffInDays < 30) return `${Math.floor(diffInDays / 7)} weeks ago`;
+    return date.toLocaleDateString();
+  };
+
+  const renderReviewCard = (data: ReviewData) => (
+    <TouchableOpacity
+      key={data.review.id}
+      style={styles.reviewCard}
+      onPress={() => navigateToAlbum(data.album.id)}
+    >
+      <View style={styles.reviewHeader}>
+        <Image source={{ uri: data.album.coverImageUrl }} style={styles.albumCover} />
+        <View style={styles.albumInfo}>
+          <Text variant="titleMedium" numberOfLines={2} style={styles.albumTitle}>
+            {data.album.title}
+          </Text>
+          <Text variant="bodyMedium" numberOfLines={1} style={styles.artistName}>
+            {data.album.artist}
+          </Text>
+          <View style={styles.ratingRow}>
+            <StarDisplay rating={data.review.rating} />
+            <Text variant="bodySmall" style={styles.reviewDate}>
+              {formatReviewDate(new Date(data.review.dateReviewed))}
+            </Text>
+          </View>
+        </View>
+      </View>
+      
+      {data.review.reviewText && (
+        <View style={styles.reviewContent}>
+          <Text variant="bodyMedium" style={styles.reviewText}>
+            {data.review.reviewText}
+          </Text>
+        </View>
+      )}
+      
+      <View style={styles.reviewStats}>
+        <View style={styles.statItem}>
+          <Text variant="bodySmall" style={styles.statText}>
+            {data.review.likesCount} like{data.review.likesCount !== 1 ? 's' : ''}
+          </Text>
+        </View>
+        <View style={styles.statItem}>
+          <Text variant="bodySmall" style={styles.statText}>
+            {data.review.commentsCount} comment{data.review.commentsCount !== 1 ? 's' : ''}
+          </Text>
+        </View>
+      </View>
+    </TouchableOpacity>
+  );
+
+  if (loading) {
+    return (
+      <View style={styles.centerContainer}>
+        <ActivityIndicator size="large" />
+        <Text variant="bodyLarge" style={styles.loadingText}>
+          Loading reviews...
+        </Text>
+      </View>
+    );
+  }
+
+  const averageRating = reviews.length > 0 
+    ? reviews.reduce((sum, data) => sum + data.review.rating, 0) / reviews.length
+    : 0;
+
+  return (
+    <View style={styles.container}>
+      {/* Header */}
+      <View style={styles.header}>
+        <IconButton
+          icon="arrow-left"
+          onPress={() => navigation.goBack()}
+          style={styles.backButton}
+        />
+        <View style={styles.headerContent}>
+          <Text variant="headlineSmall" style={styles.headerTitle}>
+            Reviews
+          </Text>
+          <Text variant="bodyMedium" style={styles.headerSubtitle}>
+            @{username} • {reviews.length} review{reviews.length !== 1 ? 's' : ''}
+            {reviews.length > 0 && ` • ${averageRating.toFixed(1)}★ avg`}
+          </Text>
+        </View>
+      </View>
+
+      {reviews.length === 0 ? (
+        <View style={styles.emptyContainer}>
+          <Text variant="titleLarge" style={styles.emptyTitle}>
+            No Reviews Yet
+          </Text>
+          <Text variant="bodyMedium" style={styles.emptyText}>
+            {username === 'you' ? 'Start rating albums and they\'ll appear here!' : `${username} hasn't reviewed any albums yet.`}
+          </Text>
+        </View>
+      ) : (
+        <ScrollView style={styles.scrollView} showsVerticalScrollIndicator={false}>
+          <View style={styles.reviewsList}>
+            {reviews.map(renderReviewCard)}
+          </View>
+          <View style={styles.bottomPadding} />
+        </ScrollView>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: theme.colors.background,
+  },
+  centerContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: theme.colors.background,
+  },
+  loadingText: {
+    marginTop: spacing.md,
+    color: theme.colors.textSecondary,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    padding: spacing.lg,
+    backgroundColor: theme.colors.surface,
+    borderBottomWidth: 1,
+    borderBottomColor: theme.colors.border,
+  },
+  backButton: {
+    margin: 0,
+  },
+  headerContent: {
+    flex: 1,
+    marginLeft: spacing.sm,
+  },
+  headerTitle: {
+    fontWeight: 'bold',
+  },
+  headerSubtitle: {
+    color: theme.colors.textSecondary,
+    marginTop: spacing.xs,
+  },
+  scrollView: {
+    flex: 1,
+  },
+  reviewsList: {
+    padding: spacing.lg,
+  },
+  reviewCard: {
+    backgroundColor: theme.colors.surface,
+    borderRadius: 12,
+    marginBottom: spacing.lg,
+    ...shadows.small,
+  },
+  reviewHeader: {
+    flexDirection: 'row',
+    padding: spacing.md,
+  },
+  albumCover: {
+    width: 80,
+    height: 80,
+    borderRadius: 8,
+    resizeMode: 'cover',
+  },
+  albumInfo: {
+    flex: 1,
+    marginLeft: spacing.md,
+    justifyContent: 'space-between',
+  },
+  albumTitle: {
+    fontWeight: '600',
+  },
+  artistName: {
+    color: theme.colors.textSecondary,
+  },
+  ratingRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  starContainer: {
+    flexDirection: 'row',
+  },
+  star: {
+    fontSize: 16,
+    marginRight: 2,
+  },
+  starFilled: {
+    color: theme.colors.primary,
+  },
+  starEmpty: {
+    color: '#ccc',
+  },
+  reviewDate: {
+    color: theme.colors.textSecondary,
+    fontSize: 12,
+  },
+  reviewContent: {
+    paddingHorizontal: spacing.md,
+    paddingBottom: spacing.md,
+  },
+  reviewText: {
+    lineHeight: 20,
+  },
+  reviewStats: {
+    flexDirection: 'row',
+    paddingHorizontal: spacing.md,
+    paddingBottom: spacing.md,
+    borderTopWidth: 1,
+    borderTopColor: theme.colors.border,
+    paddingTop: spacing.sm,
+  },
+  statItem: {
+    marginRight: spacing.lg,
+  },
+  statText: {
+    color: theme.colors.textSecondary,
+    fontSize: 12,
+  },
+  emptyContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: spacing.xl,
+  },
+  emptyTitle: {
+    fontWeight: 'bold',
+    marginBottom: spacing.md,
+    textAlign: 'center',
+  },
+  emptyText: {
+    color: theme.colors.textSecondary,
+    textAlign: 'center',
+    lineHeight: 22,
+  },
+  bottomPadding: {
+    height: spacing.xl,
+  },
+});

--- a/Musicboxd/src/screens/Profile/UserReviewsScreen.tsx
+++ b/Musicboxd/src/screens/Profile/UserReviewsScreen.tsx
@@ -25,7 +25,7 @@ type UserReviewsScreenRouteProp = RouteProp<
   'UserReviews'
 >;
 type UserReviewsScreenNavigationProp = StackNavigationProp<
-  HomeStackParamList | SearchStackParamList | ProfileStackParamList
+  HomeStackParamList & SearchStackParamList & ProfileStackParamList
 >;
 
 
@@ -93,7 +93,7 @@ export default function UserReviewsScreen() {
   }, [loadUserReviews]);
 
   const navigateToAlbum = (albumId: string) => {
-    (navigation as any).navigate('AlbumDetails', { albumId });
+    navigation.navigate('AlbumDetails', { albumId });
   };
 
   const formatReviewDate = (date: Date) => {

--- a/Musicboxd/src/screens/Profile/UserReviewsScreen.tsx
+++ b/Musicboxd/src/screens/Profile/UserReviewsScreen.tsx
@@ -24,9 +24,7 @@ type UserReviewsScreenRouteProp = RouteProp<
   HomeStackParamList | SearchStackParamList | ProfileStackParamList,
   'UserReviews'
 >;
-type UserReviewsScreenNavigationProp = StackNavigationProp<
-  HomeStackParamList & SearchStackParamList & ProfileStackParamList
->;
+type UserReviewsScreenNavigationProp = StackNavigationProp<ProfileStackParamList>;
 
 
 

--- a/Musicboxd/src/screens/Profile/UserReviewsScreen.tsx
+++ b/Musicboxd/src/screens/Profile/UserReviewsScreen.tsx
@@ -13,10 +13,12 @@ import {
 } from 'react-native-paper';
 import { RouteProp, useRoute, useNavigation } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
+import { useSelector } from 'react-redux';
 
 import { theme, spacing, shadows } from '../../utils/theme';
 import { Review, Album, HomeStackParamList, SearchStackParamList, ProfileStackParamList } from '../../types';
 import { AlbumService } from '../../services/albumService';
+import { RootState } from '../../store';
 
 type UserReviewsScreenRouteProp = RouteProp<
   HomeStackParamList | SearchStackParamList | ProfileStackParamList,
@@ -53,6 +55,7 @@ export default function UserReviewsScreen() {
   const route = useRoute<UserReviewsScreenRouteProp>();
   const navigation = useNavigation<UserReviewsScreenNavigationProp>();
   const { userId, username } = route.params;
+  const { user: currentUser } = useSelector((state: RootState) => state.auth);
 
   const [reviews, setReviews] = useState<ReviewData[]>([]);
   const [loading, setLoading] = useState(true);
@@ -171,7 +174,7 @@ export default function UserReviewsScreen() {
             No Ratings Yet
           </Text>
           <Text variant="bodyMedium" style={styles.emptyText}>
-            {username === 'you' ? 'Start rating albums and they\'ll appear here!' : `${username} hasn't rated any albums yet.`}
+            {userId === currentUser?.id ? 'Start rating albums and they\'ll appear here!' : `${username} hasn't rated any albums yet.`}
           </Text>
         </View>
       ) : (

--- a/Musicboxd/src/screens/Profile/UserReviewsScreen.tsx
+++ b/Musicboxd/src/screens/Profile/UserReviewsScreen.tsx
@@ -127,27 +127,6 @@ export default function UserReviewsScreen() {
           </View>
         </View>
       </View>
-      
-      {data.review.reviewText && (
-        <View style={styles.reviewContent}>
-          <Text variant="bodyMedium" style={styles.reviewText}>
-            {data.review.reviewText}
-          </Text>
-        </View>
-      )}
-      
-      <View style={styles.reviewStats}>
-        <View style={styles.statItem}>
-          <Text variant="bodySmall" style={styles.statText}>
-            {data.review.likesCount} like{data.review.likesCount !== 1 ? 's' : ''}
-          </Text>
-        </View>
-        <View style={styles.statItem}>
-          <Text variant="bodySmall" style={styles.statText}>
-            {data.review.commentsCount} comment{data.review.commentsCount !== 1 ? 's' : ''}
-          </Text>
-        </View>
-      </View>
     </TouchableOpacity>
   );
 
@@ -156,7 +135,7 @@ export default function UserReviewsScreen() {
       <View style={styles.centerContainer}>
         <ActivityIndicator size="large" />
         <Text variant="bodyLarge" style={styles.loadingText}>
-          Loading reviews...
+          Loading ratings...
         </Text>
       </View>
     );
@@ -177,10 +156,10 @@ export default function UserReviewsScreen() {
         />
         <View style={styles.headerContent}>
           <Text variant="headlineSmall" style={styles.headerTitle}>
-            Reviews
+            Ratings
           </Text>
           <Text variant="bodyMedium" style={styles.headerSubtitle}>
-            @{username} • {reviews.length} review{reviews.length !== 1 ? 's' : ''}
+            @{username} • {reviews.length} rating{reviews.length !== 1 ? 's' : ''}
             {reviews.length > 0 && ` • ${averageRating.toFixed(1)}★ avg`}
           </Text>
         </View>
@@ -189,10 +168,10 @@ export default function UserReviewsScreen() {
       {reviews.length === 0 ? (
         <View style={styles.emptyContainer}>
           <Text variant="titleLarge" style={styles.emptyTitle}>
-            No Reviews Yet
+            No Ratings Yet
           </Text>
           <Text variant="bodyMedium" style={styles.emptyText}>
-            {username === 'you' ? 'Start rating albums and they\'ll appear here!' : `${username} hasn't reviewed any albums yet.`}
+            {username === 'you' ? 'Start rating albums and they\'ll appear here!' : `${username} hasn't rated any albums yet.`}
           </Text>
         </View>
       ) : (
@@ -296,28 +275,6 @@ const styles = StyleSheet.create({
     color: '#ccc',
   },
   reviewDate: {
-    color: theme.colors.textSecondary,
-    fontSize: 12,
-  },
-  reviewContent: {
-    paddingHorizontal: spacing.md,
-    paddingBottom: spacing.md,
-  },
-  reviewText: {
-    lineHeight: 20,
-  },
-  reviewStats: {
-    flexDirection: 'row',
-    paddingHorizontal: spacing.md,
-    paddingBottom: spacing.md,
-    borderTopWidth: 1,
-    borderTopColor: theme.colors.border,
-    paddingTop: spacing.sm,
-  },
-  statItem: {
-    marginRight: spacing.lg,
-  },
-  statText: {
     color: theme.colors.textSecondary,
     fontSize: 12,
   },

--- a/Musicboxd/src/screens/Search/SearchScreen.tsx
+++ b/Musicboxd/src/screens/Search/SearchScreen.tsx
@@ -47,10 +47,6 @@ export default function SearchScreen() {
 
   const [popularGenres, setPopularGenres] = useState<string[]>([]);
 
-  useEffect(() => {
-    loadInitialData();
-  }, [loadInitialData]);
-
   const loadInitialData = useCallback(async () => {
     try {
       const [trendingResponse, genresResponse] = await Promise.all([
@@ -69,6 +65,10 @@ export default function SearchScreen() {
       console.error('Error loading initial data:', error);
     }
   }, [dispatch]);
+
+  useEffect(() => {
+    loadInitialData();
+  }, [loadInitialData]);
 
   const performSearch = useCallback(async (query: string) => {
     if (query.trim()) {
@@ -244,7 +244,7 @@ export default function SearchScreen() {
             </Text>
             <ScrollView horizontal showsHorizontalScrollIndicator={false}>
               <View style={styles.trendingContainer}>
-                {trendingAlbums.map((album, index) => renderTrendingAlbum(album, index))}
+                {trendingAlbums.map((album) => renderTrendingAlbum(album))}
               </View>
             </ScrollView>
           </View>

--- a/Musicboxd/src/services/albumService.ts
+++ b/Musicboxd/src/services/albumService.ts
@@ -33,7 +33,6 @@ export class AlbumService {
       userId: 'current-user-id',
       albumId: '1',
       dateListened: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000), // 2 days ago
-      notes: 'Amazing album!',
     },
     {
       id: 'listen_demo_2',
@@ -46,7 +45,6 @@ export class AlbumService {
       userId: 'current-user-id',
       albumId: '4',
       dateListened: new Date(Date.now() - 10 * 24 * 60 * 60 * 1000), // 10 days ago
-      notes: 'Such a beautiful and emotional journey',
     },
     {
       id: 'listen_demo_4',
@@ -59,7 +57,6 @@ export class AlbumService {
       userId: 'current-user-id',
       albumId: '5',
       dateListened: new Date(Date.now() - 20 * 24 * 60 * 60 * 1000), // 20 days ago
-      notes: 'Classic hip-hop at its finest',
     },
   ];
   

--- a/Musicboxd/src/services/albumService.ts
+++ b/Musicboxd/src/services/albumService.ts
@@ -4,6 +4,26 @@ import { mockAlbums, popularGenres } from './mockData';
 // Simulate API delay
 const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 
+// Helper to serialize a review
+function serializeReview(review: Review): any {
+  return {
+    ...review,
+    dateReviewed: review.dateReviewed instanceof Date
+      ? review.dateReviewed.toISOString()
+      : review.dateReviewed,
+  };
+}
+
+// Helper to serialize a listen
+function serializeListen(listen: Listen): any {
+  return {
+    ...listen,
+    dateListened: listen.dateListened instanceof Date
+      ? listen.dateListened.toISOString()
+      : listen.dateListened,
+  };
+}
+
 export class AlbumService {
   // Store user interactions in memory (in real app, this would be API calls)
   private static userListens: Listen[] = [
@@ -167,7 +187,7 @@ export class AlbumService {
     
     if (existingListen) {
       return {
-        data: existingListen,
+        data: serializeListen(existingListen),
         success: false,
         message: 'Album already marked as listened',
       };
@@ -184,7 +204,7 @@ export class AlbumService {
     this.userListens.push(newListen);
 
     return {
-      data: newListen,
+      data: serializeListen(newListen),
       success: true,
       message: 'Album marked as listened',
     };
@@ -248,7 +268,7 @@ export class AlbumService {
       this.userReviews[existingReviewIndex] = updatedReview;
       
       return {
-        data: updatedReview,
+        data: serializeReview(updatedReview),
         success: true,
         message: 'Review updated',
       };
@@ -268,7 +288,7 @@ export class AlbumService {
       this.userReviews.push(newReview);
 
       return {
-        data: newReview,
+        data: serializeReview(newReview),
         success: true,
         message: 'Review added',
       };
@@ -302,21 +322,26 @@ export class AlbumService {
 
   // Get user's review for album
   static async getUserReview(userId: string, albumId: string): Promise<Review | null> {
-    return this.userReviews.find(
+    const review = this.userReviews.find(
       review => review.userId === userId && review.albumId === albumId
     ) || null;
+    return review ? serializeReview(review) : null;
   }
 
   // Get user's listens
   static async getUserListens(userId: string): Promise<Listen[]> {
     await delay(300);
-    return this.userListens.filter(listen => listen.userId === userId);
+    return this.userListens
+      .filter(listen => listen.userId === userId)
+      .map(serializeListen);
   }
 
   // Get user's reviews
   static async getUserReviews(userId: string): Promise<Review[]> {
     await delay(300);
-    return this.userReviews.filter(review => review.userId === userId);
+    return this.userReviews
+      .filter(review => review.userId === userId)
+      .map(serializeReview);
   }
 
   // Get user stats

--- a/Musicboxd/src/services/albumService.ts
+++ b/Musicboxd/src/services/albumService.ts
@@ -41,6 +41,26 @@ export class AlbumService {
       albumId: '3',
       dateListened: new Date(Date.now() - 5 * 24 * 60 * 60 * 1000), // 5 days ago
     },
+    {
+      id: 'listen_demo_3',
+      userId: 'current-user-id',
+      albumId: '4',
+      dateListened: new Date(Date.now() - 10 * 24 * 60 * 60 * 1000), // 10 days ago
+      notes: 'Such a beautiful and emotional journey',
+    },
+    {
+      id: 'listen_demo_4',
+      userId: 'current-user-id',
+      albumId: '2',
+      dateListened: new Date(Date.now() - 15 * 24 * 60 * 60 * 1000), // 15 days ago
+    },
+    {
+      id: 'listen_demo_5',
+      userId: 'current-user-id',
+      albumId: '5',
+      dateListened: new Date(Date.now() - 20 * 24 * 60 * 60 * 1000), // 20 days ago
+      notes: 'Classic hip-hop at its finest',
+    },
   ];
   
   private static userReviews: Review[] = [
@@ -50,7 +70,7 @@ export class AlbumService {
       userId: 'current-user-id',
       albumId: '1',
       rating: 5,
-      reviewText: 'A masterpiece that defined a generation.',
+      reviewText: 'A masterpiece that defined a generation. Every track flows perfectly into the next, creating an immersive experience that captures the alienation and technological anxiety of the late 90s.',
       dateReviewed: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000),
       likesCount: 12,
       commentsCount: 3,
@@ -60,10 +80,30 @@ export class AlbumService {
       userId: 'current-user-id',
       albumId: '3',
       rating: 4,
-      reviewText: 'Incredible work by Kendrick.',
+      reviewText: 'Incredible work by Kendrick. A bold and complex exploration of identity, race, and self-love. The jazz influences make it stand out from typical hip-hop.',
       dateReviewed: new Date(Date.now() - 5 * 24 * 60 * 60 * 1000),
       likesCount: 8,
       commentsCount: 2,
+    },
+    {
+      id: 'review_demo_3',
+      userId: 'current-user-id',
+      albumId: '4',
+      rating: 5,
+      reviewText: 'Frank Ocean\'s most personal and vulnerable work. The production is gorgeous and his vocals are haunting.',
+      dateReviewed: new Date(Date.now() - 10 * 24 * 60 * 60 * 1000),
+      likesCount: 15,
+      commentsCount: 5,
+    },
+    {
+      id: 'review_demo_4',
+      userId: 'current-user-id',
+      albumId: '2',
+      rating: 5,
+      reviewText: 'Perfect follow-up to OK Computer. More experimental but equally compelling.',
+      dateReviewed: new Date(Date.now() - 15 * 24 * 60 * 60 * 1000),
+      likesCount: 6,
+      commentsCount: 1,
     },
   ];
 

--- a/Musicboxd/src/services/albumService.ts
+++ b/Musicboxd/src/services/albumService.ts
@@ -64,46 +64,42 @@ export class AlbumService {
   ];
   
   private static userReviews: Review[] = [
-    // Add some demo data for testing
+    // Add some demo ratings data for testing
     {
       id: 'review_demo_1',
       userId: 'current-user-id',
       albumId: '1',
       rating: 5,
-      reviewText: 'A masterpiece that defined a generation. Every track flows perfectly into the next, creating an immersive experience that captures the alienation and technological anxiety of the late 90s.',
       dateReviewed: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000),
-      likesCount: 12,
-      commentsCount: 3,
+      likesCount: 0,
+      commentsCount: 0,
     },
     {
       id: 'review_demo_2',
       userId: 'current-user-id',
       albumId: '3',
       rating: 4,
-      reviewText: 'Incredible work by Kendrick. A bold and complex exploration of identity, race, and self-love. The jazz influences make it stand out from typical hip-hop.',
       dateReviewed: new Date(Date.now() - 5 * 24 * 60 * 60 * 1000),
-      likesCount: 8,
-      commentsCount: 2,
+      likesCount: 0,
+      commentsCount: 0,
     },
     {
       id: 'review_demo_3',
       userId: 'current-user-id',
       albumId: '4',
       rating: 5,
-      reviewText: 'Frank Ocean\'s most personal and vulnerable work. The production is gorgeous and his vocals are haunting.',
       dateReviewed: new Date(Date.now() - 10 * 24 * 60 * 60 * 1000),
-      likesCount: 15,
-      commentsCount: 5,
+      likesCount: 0,
+      commentsCount: 0,
     },
     {
       id: 'review_demo_4',
       userId: 'current-user-id',
       albumId: '2',
       rating: 5,
-      reviewText: 'Perfect follow-up to OK Computer. More experimental but equally compelling.',
       dateReviewed: new Date(Date.now() - 15 * 24 * 60 * 60 * 1000),
-      likesCount: 6,
-      commentsCount: 1,
+      likesCount: 0,
+      commentsCount: 0,
     },
   ];
 
@@ -282,7 +278,7 @@ export class AlbumService {
     );
   }
 
-  // Add or update review
+  // Add or update rating
   static async addReview(
     userId: string, 
     albumId: string, 

--- a/Musicboxd/src/services/albumService.ts
+++ b/Musicboxd/src/services/albumService.ts
@@ -1,10 +1,52 @@
-import { Album, SearchResult, ApiResponse } from '../types';
+import { Album, SearchResult, ApiResponse, Listen, Review } from '../types';
 import { mockAlbums, popularGenres } from './mockData';
 
 // Simulate API delay
 const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 
 export class AlbumService {
+  // Store user interactions in memory (in real app, this would be API calls)
+  private static userListens: Listen[] = [
+    // Add some demo data for testing
+    {
+      id: 'listen_demo_1',
+      userId: 'current-user-id',
+      albumId: '1',
+      dateListened: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000), // 2 days ago
+      notes: 'Amazing album!',
+    },
+    {
+      id: 'listen_demo_2',
+      userId: 'current-user-id',
+      albumId: '3',
+      dateListened: new Date(Date.now() - 5 * 24 * 60 * 60 * 1000), // 5 days ago
+    },
+  ];
+  
+  private static userReviews: Review[] = [
+    // Add some demo data for testing
+    {
+      id: 'review_demo_1',
+      userId: 'current-user-id',
+      albumId: '1',
+      rating: 5,
+      reviewText: 'A masterpiece that defined a generation.',
+      dateReviewed: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000),
+      likesCount: 12,
+      commentsCount: 3,
+    },
+    {
+      id: 'review_demo_2',
+      userId: 'current-user-id',
+      albumId: '3',
+      rating: 4,
+      reviewText: 'Incredible work by Kendrick.',
+      dateReviewed: new Date(Date.now() - 5 * 24 * 60 * 60 * 1000),
+      likesCount: 8,
+      commentsCount: 2,
+    },
+  ];
+
   // Fetch popular/trending albums
   static async getPopularAlbums(): Promise<ApiResponse<Album[]>> {
     await delay(500);
@@ -111,6 +153,189 @@ export class AlbumService {
       data: popularGenres,
       success: true,
       message: 'Popular genres fetched',
+    };
+  }
+
+  // Mark album as listened
+  static async markAsListened(userId: string, albumId: string, notes?: string): Promise<ApiResponse<Listen>> {
+    await delay(300);
+    
+    // Check if already listened
+    const existingListen = this.userListens.find(
+      listen => listen.userId === userId && listen.albumId === albumId
+    );
+    
+    if (existingListen) {
+      return {
+        data: existingListen,
+        success: false,
+        message: 'Album already marked as listened',
+      };
+    }
+
+    const newListen: Listen = {
+      id: `listen_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`,
+      userId,
+      albumId,
+      dateListened: new Date(),
+      notes,
+    };
+
+    this.userListens.push(newListen);
+
+    return {
+      data: newListen,
+      success: true,
+      message: 'Album marked as listened',
+    };
+  }
+
+  // Remove listen
+  static async removeListened(userId: string, albumId: string): Promise<ApiResponse<void>> {
+    await delay(300);
+    
+    const index = this.userListens.findIndex(
+      listen => listen.userId === userId && listen.albumId === albumId
+    );
+    
+    if (index === -1) {
+      return {
+        data: undefined,
+        success: false,
+        message: 'Listen not found',
+      };
+    }
+
+    this.userListens.splice(index, 1);
+
+    return {
+      data: undefined,
+      success: true,
+      message: 'Listen removed',
+    };
+  }
+
+  // Check if user has listened to album
+  static async hasUserListened(userId: string, albumId: string): Promise<boolean> {
+    return this.userListens.some(
+      listen => listen.userId === userId && listen.albumId === albumId
+    );
+  }
+
+  // Add or update review
+  static async addReview(
+    userId: string, 
+    albumId: string, 
+    rating: number, 
+    reviewText?: string
+  ): Promise<ApiResponse<Review>> {
+    await delay(300);
+    
+    // Check if review already exists
+    const existingReviewIndex = this.userReviews.findIndex(
+      review => review.userId === userId && review.albumId === albumId
+    );
+
+    if (existingReviewIndex !== -1) {
+      // Update existing review
+      const updatedReview: Review = {
+        ...this.userReviews[existingReviewIndex],
+        rating,
+        reviewText,
+        dateReviewed: new Date(),
+      };
+      
+      this.userReviews[existingReviewIndex] = updatedReview;
+      
+      return {
+        data: updatedReview,
+        success: true,
+        message: 'Review updated',
+      };
+    } else {
+      // Create new review
+      const newReview: Review = {
+        id: `review_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`,
+        userId,
+        albumId,
+        rating,
+        reviewText,
+        dateReviewed: new Date(),
+        likesCount: 0,
+        commentsCount: 0,
+      };
+
+      this.userReviews.push(newReview);
+
+      return {
+        data: newReview,
+        success: true,
+        message: 'Review added',
+      };
+    }
+  }
+
+  // Remove review
+  static async removeReview(userId: string, albumId: string): Promise<ApiResponse<void>> {
+    await delay(300);
+    
+    const index = this.userReviews.findIndex(
+      review => review.userId === userId && review.albumId === albumId
+    );
+    
+    if (index === -1) {
+      return {
+        data: undefined,
+        success: false,
+        message: 'Review not found',
+      };
+    }
+
+    this.userReviews.splice(index, 1);
+
+    return {
+      data: undefined,
+      success: true,
+      message: 'Review removed',
+    };
+  }
+
+  // Get user's review for album
+  static async getUserReview(userId: string, albumId: string): Promise<Review | null> {
+    return this.userReviews.find(
+      review => review.userId === userId && review.albumId === albumId
+    ) || null;
+  }
+
+  // Get user's listens
+  static async getUserListens(userId: string): Promise<Listen[]> {
+    await delay(300);
+    return this.userListens.filter(listen => listen.userId === userId);
+  }
+
+  // Get user's reviews
+  static async getUserReviews(userId: string): Promise<Review[]> {
+    await delay(300);
+    return this.userReviews.filter(review => review.userId === userId);
+  }
+
+  // Get user stats
+  static async getUserAlbumStats(userId: string): Promise<{
+    albumsListened: number;
+    reviews: number;
+    averageRating: number;
+  }> {
+    const userListens = await this.getUserListens(userId);
+    const userReviews = await this.getUserReviews(userId);
+    
+    const averageRating = userReviews.length > 0 
+      ? userReviews.reduce((sum, review) => sum + review.rating, 0) / userReviews.length
+      : 0;
+
+    return {
+      albumsListened: userListens.length,
+      reviews: userReviews.length,
+      averageRating: Math.round(averageRating * 10) / 10, // Round to 1 decimal place
     };
   }
 

--- a/Musicboxd/src/services/albumService.ts
+++ b/Musicboxd/src/services/albumService.ts
@@ -356,7 +356,7 @@ export class AlbumService {
   // Get user's review for album
   static async getUserReview(userId: string, albumId: string): Promise<Review | null> {
     const review = this.userReviews.find(
-      review => review.userId === userId && review.albumId === albumId
+      r => r.userId === userId && r.albumId === albumId
     ) || null;
     return review ? serializeReview(review) : null;
   }

--- a/Musicboxd/src/services/userService.ts
+++ b/Musicboxd/src/services/userService.ts
@@ -298,11 +298,11 @@ class UserService {
     const albumStats = await AlbumService.getUserAlbumStats(userId);
     
     // Get static data for lists (would be from a lists service in real app)
-    const getListsCreated = (userId: string) => {
-      if (userId === 'current-user-id') return 3;
-      if (userId === 'user1') return 5;
-      if (userId === 'user2') return 12;
-      if (userId === 'user3') return 8;
+    const getListsCreated = (targetUserId: string) => {
+      if (targetUserId === 'current-user-id') return 3;
+      if (targetUserId === 'user1') return 5;
+      if (targetUserId === 'user2') return 12;
+      if (targetUserId === 'user3') return 8;
       return 0;
     };
     

--- a/Musicboxd/src/services/userService.ts
+++ b/Musicboxd/src/services/userService.ts
@@ -1,4 +1,5 @@
 import { User, Activity, Follow } from '../types';
+import { AlbumService } from './albumService';
 
 class UserService {
   // Mock data for demonstration - in real app, these would be API calls
@@ -293,49 +294,26 @@ class UserService {
     const followingCount = this.followRelationships.filter(f => f.followerId === userId).length;
     const followersCount = this.followRelationships.filter(f => f.followingId === userId).length;
     
-    // Return stats with actual counts for the requested user
-    if (userId === 'current-user-id') {
-      return {
-        albumsListened: 127,
-        reviews: 23,
-        following: followingCount,
-        followers: followersCount,
-        listsCreated: 3,
-      };
-    } else if (userId === 'user1') {
-      return {
-        albumsListened: 89,
-        reviews: 34,
-        following: followingCount,
-        followers: followersCount,
-        listsCreated: 5,
-      };
-    } else if (userId === 'user2') {
-      return {
-        albumsListened: 156,
-        reviews: 67,
-        following: followingCount,
-        followers: followersCount,
-        listsCreated: 12,
-      };
-    } else if (userId === 'user3') {
-      return {
-        albumsListened: 203,
-        reviews: 45,
-        following: followingCount,
-        followers: followersCount,
-        listsCreated: 8,
-      };
-    } else {
-      // Default for unknown users
-      return {
-        albumsListened: 0,
-        reviews: 0,
-        following: followingCount,
-        followers: followersCount,
-        listsCreated: 0,
-      };
-    }
+    // Get real album stats from AlbumService
+    const albumStats = await AlbumService.getUserAlbumStats(userId);
+    
+    // Get static data for lists (would be from a lists service in real app)
+    const getListsCreated = (userId: string) => {
+      if (userId === 'current-user-id') return 3;
+      if (userId === 'user1') return 5;
+      if (userId === 'user2') return 12;
+      if (userId === 'user3') return 8;
+      return 0;
+    };
+    
+    return {
+      albumsListened: albumStats.albumsListened,
+      reviews: albumStats.reviews,
+      averageRating: albumStats.averageRating,
+      following: followingCount,
+      followers: followersCount,
+      listsCreated: getListsCreated(userId),
+    };
   }
 }
 

--- a/Musicboxd/src/store/slices/albumSlice.ts
+++ b/Musicboxd/src/store/slices/albumSlice.ts
@@ -64,6 +64,11 @@ const albumSlice = createSlice({
     addListen: (state, action: PayloadAction<Listen>) => {
       state.userListens.push(action.payload);
     },
+    removeListen: (state, action: PayloadAction<{ userId: string; albumId: string }>) => {
+      state.userListens = state.userListens.filter(
+        listen => !(listen.userId === action.payload.userId && listen.albumId === action.payload.albumId)
+      );
+    },
     setPopularAlbums: (state, action: PayloadAction<Album[]>) => {
       state.popularAlbums = action.payload;
     },
@@ -98,6 +103,7 @@ export const {
   updateReview,
   removeReview,
   addListen,
+  removeListen,
   setPopularAlbums,
   setCurrentAlbumUserReview,
   setCurrentAlbumIsListened,

--- a/Musicboxd/src/store/slices/albumSlice.ts
+++ b/Musicboxd/src/store/slices/albumSlice.ts
@@ -7,6 +7,8 @@ interface AlbumState {
   userReviews: Review[];
   userListens: Listen[];
   popularAlbums: Album[];
+  currentAlbumUserReview: Review | null;
+  currentAlbumIsListened: boolean;
   loading: boolean;
   error: string | null;
 }
@@ -17,6 +19,8 @@ const initialState: AlbumState = {
   userReviews: [],
   userListens: [],
   popularAlbums: [],
+  currentAlbumUserReview: null,
+  currentAlbumIsListened: false,
   loading: false,
   error: null,
 };
@@ -42,6 +46,8 @@ const albumSlice = createSlice({
     },
     clearCurrentAlbum: (state) => {
       state.currentAlbum = null;
+      state.currentAlbumUserReview = null;
+      state.currentAlbumIsListened = false;
     },
     addReview: (state, action: PayloadAction<Review>) => {
       state.userReviews.push(action.payload);
@@ -61,6 +67,21 @@ const albumSlice = createSlice({
     setPopularAlbums: (state, action: PayloadAction<Album[]>) => {
       state.popularAlbums = action.payload;
     },
+    setCurrentAlbumUserReview: (state, action: PayloadAction<Review | null>) => {
+      state.currentAlbumUserReview = action.payload;
+      // Update the review in userReviews array if it exists
+      if (action.payload) {
+        const index = state.userReviews.findIndex(r => r.id === action.payload!.id);
+        if (index !== -1) {
+          state.userReviews[index] = action.payload;
+        } else {
+          state.userReviews.push(action.payload);
+        }
+      }
+    },
+    setCurrentAlbumIsListened: (state, action: PayloadAction<boolean>) => {
+      state.currentAlbumIsListened = action.payload;
+    },
     clearError: (state) => {
       state.error = null;
     },
@@ -78,6 +99,8 @@ export const {
   removeReview,
   addListen,
   setPopularAlbums,
+  setCurrentAlbumUserReview,
+  setCurrentAlbumIsListened,
   clearError,
 } = albumSlice.actions;
 

--- a/Musicboxd/src/types/index.ts
+++ b/Musicboxd/src/types/index.ts
@@ -131,6 +131,8 @@ export type HomeStackParamList = {
   AlbumDetails: { albumId: string };
   UserProfile: { userId: string };
   Followers: { userId: string; username: string; initialTab?: 'followers' | 'following' };
+  ListenedAlbums: { userId: string; username: string };
+  UserReviews: { userId: string; username: string };
 };
 
 export type SearchStackParamList = {
@@ -138,12 +140,16 @@ export type SearchStackParamList = {
   AlbumDetails: { albumId: string };
   UserProfile: { userId: string };
   Followers: { userId: string; username: string; initialTab?: 'followers' | 'following' };
+  ListenedAlbums: { userId: string; username: string };
+  UserReviews: { userId: string; username: string };
 };
 
 export type ProfileStackParamList = {
   ProfileMain: undefined;
   UserProfile: { userId: string };
   Followers: { userId: string; username: string; initialTab?: 'followers' | 'following' };
+  ListenedAlbums: { userId: string; username: string };
+  UserReviews: { userId: string; username: string };
 };
 
 // Search types

--- a/Musicboxd/src/types/index.ts
+++ b/Musicboxd/src/types/index.ts
@@ -146,6 +146,7 @@ export type SearchStackParamList = {
 
 export type ProfileStackParamList = {
   ProfileMain: undefined;
+  AlbumDetails: { albumId: string };
   UserProfile: { userId: string };
   Followers: { userId: string; username: string; initialTab?: 'followers' | 'following' };
   ListenedAlbums: { userId: string; username: string };


### PR DESCRIPTION
Implement album listening and rating features to display real user stats on profiles.

This PR replaces the placeholder album listening and rating data on user profiles with actual user-generated statistics, enabling users to track their listening habits and contribute ratings.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-263f85d4-6338-4da4-8163-1c259c3df4c6) · [Cursor](https://cursor.com/background-agent?bcId=bc-263f85d4-6338-4da4-8163-1c259c3df4c6)

Learn more about [Background Agents](https://docs.cursor.com/background-agents)