### PR TITLE
Implement back buttons on specified screens

### DIFF
--- a/Musicboxd/src/navigation/AppNavigator.tsx
+++ b/Musicboxd/src/navigation/AppNavigator.tsx
@@ -99,7 +99,7 @@ function HomeStackNavigator() {
       <HomeStack.Screen
         name="HomeMain"
         component={HomeScreen}
-        options={{ title: 'Musicboxd', headerBackVisible: false }}
+        options={{ title: 'Musicboxd', headerBackVisible: false, headerLeft: () => null }}
       />
       <HomeStack.Screen
         name="PopularThisWeek"
@@ -109,7 +109,7 @@ function HomeStackNavigator() {
           title: '',
           headerBackVisible: false,
           headerLeft: () => <BackButton navigation={navigation} customOnPress={() => {
-            navigation.navigate('HomeMain');
+            navigation.goBack();
           }} />,
         })}
       />
@@ -121,7 +121,7 @@ function HomeStackNavigator() {
           title: '',
           headerBackVisible: false,
           headerLeft: () => <BackButton navigation={navigation} customOnPress={() => {
-            navigation.navigate('HomeMain');
+            navigation.goBack();
           }} />,
         })}
       />
@@ -133,7 +133,7 @@ function HomeStackNavigator() {
           title: '',
           headerBackVisible: false,
           headerLeft: () => <BackButton navigation={navigation} customOnPress={() => {
-            navigation.navigate('HomeMain');
+            navigation.goBack();
           }} />,
         })}
       />
@@ -243,7 +243,7 @@ function SearchStackNavigator() {
       <SearchStack.Screen
         name="SearchMain"
         component={SearchScreen}
-        options={{ title: 'Search', headerBackVisible: false }}
+        options={{ title: 'Search', headerBackVisible: false, headerLeft: () => null }}
       />
       <SearchStack.Screen
         name="PopularThisWeek"
@@ -253,7 +253,7 @@ function SearchStackNavigator() {
           title: '',
           headerBackVisible: false,
           headerLeft: () => <BackButton navigation={navigation} customOnPress={() => {
-            navigation.navigate('SearchMain');
+            navigation.goBack();
           }} />,
         })}
       />
@@ -265,7 +265,7 @@ function SearchStackNavigator() {
           title: '',
           headerBackVisible: false,
           headerLeft: () => <BackButton navigation={navigation} customOnPress={() => {
-            navigation.navigate('SearchMain');
+            navigation.goBack();
           }} />,
         })}
       />
@@ -277,7 +277,7 @@ function SearchStackNavigator() {
           title: '',
           headerBackVisible: false,
           headerLeft: () => <BackButton navigation={navigation} customOnPress={() => {
-            navigation.navigate('SearchMain');
+            navigation.goBack();
           }} />,
         })}
       />
@@ -397,7 +397,7 @@ function ProfileStackNavigator() {
           title: '',
           headerBackVisible: false,
           headerLeft: () => <BackButton navigation={navigation} customOnPress={() => {
-            navigation.navigate('ProfileMain');
+            navigation.goBack();
           }} />,
         })}
       />
@@ -409,7 +409,7 @@ function ProfileStackNavigator() {
           title: '',
           headerBackVisible: false,
           headerLeft: () => <BackButton navigation={navigation} customOnPress={() => {
-            navigation.navigate('ProfileMain');
+            navigation.goBack();
           }} />,
         })}
       />
@@ -421,7 +421,7 @@ function ProfileStackNavigator() {
           title: '',
           headerBackVisible: false,
           headerLeft: () => <BackButton navigation={navigation} customOnPress={() => {
-            navigation.navigate('ProfileMain');
+            navigation.goBack();
           }} />,
         })}
       />

--- a/Musicboxd/src/navigation/AppNavigator.tsx
+++ b/Musicboxd/src/navigation/AppNavigator.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { NavigationContainer } from '@react-navigation/native';
 import { createStackNavigator } from '@react-navigation/stack';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
-import { Text, useColorScheme } from 'react-native';
+import { Text, useColorScheme, TouchableOpacity } from 'react-native';
 import { useSelector } from 'react-redux';
 
 import { RootStackParamList, MainTabParamList } from '../types';
@@ -28,6 +28,29 @@ import DiaryEntryDetailsScreen from '../screens/Profile/DiaryEntryDetailsScreen'
 
 const Stack = createStackNavigator<RootStackParamList>();
 const Tab = createBottomTabNavigator<MainTabParamList>();
+
+// Back button component
+const BackButton = ({ navigation, customOnPress }: { navigation: any; customOnPress?: () => void }) => {
+  const isDark = useColorScheme() === 'dark';
+  const currentTheme = isDark ? theme.dark : theme.light;
+  
+  const handlePress = () => {
+    if (customOnPress) {
+      customOnPress();
+    } else if (navigation.canGoBack()) {
+      navigation.goBack();
+    }
+  };
+
+  return (
+    <TouchableOpacity 
+      onPress={handlePress}
+      style={{ paddingLeft: 16, paddingRight: 8, paddingVertical: 8 }}
+    >
+      <Text style={{ fontSize: 18, color: currentTheme.colors.onSurface }}>←</Text>
+    </TouchableOpacity>
+  );
+};
 
 // Tab icon component to avoid creating it during render
 const TabIcon = ({ routeName, color, size }: { routeName: string; color: string; size: number }) => {
@@ -81,60 +104,107 @@ function HomeStackNavigator() {
       <HomeStack.Screen
         name="PopularThisWeek"
         component={PopularThisWeekScreen}
-        options={{
-          headerShown: false,
-        }}
+        options={({ navigation }) => ({
+          headerShown: true,
+          title: '',
+          headerBackVisible: false,
+          headerLeft: () => <BackButton navigation={navigation} customOnPress={() => {
+            navigation.navigate('HomeMain');
+          }} />,
+        })}
       />
       <HomeStack.Screen
         name="NewFromFriends"
         component={NewFromFriendsScreen}
-        options={{
-          headerShown: false,
-        }}
+        options={({ navigation }) => ({
+          headerShown: true,
+          title: '',
+          headerBackVisible: false,
+          headerLeft: () => <BackButton navigation={navigation} customOnPress={() => {
+            navigation.navigate('HomeMain');
+          }} />,
+        })}
       />
       <HomeStack.Screen
         name="PopularWithFriends"
         component={PopularWithFriendsScreen}
-        options={{
-          headerShown: false,
-        }}
+        options={({ navigation }) => ({
+          headerShown: true,
+          title: '',
+          headerBackVisible: false,
+          headerLeft: () => <BackButton navigation={navigation} customOnPress={() => {
+            navigation.navigate('HomeMain');
+          }} />,
+        })}
       />
       <HomeStack.Screen
         name="AlbumDetails"
         component={AlbumDetailsScreen}
-        options={{
+        options={({ navigation }) => ({
           title: 'Album Details',
           headerBackVisible: false,
-          headerLeft: () => null,
-        }}
+          headerLeft: () => <BackButton navigation={navigation} />,
+        })}
       />
       <HomeStack.Screen
         name="UserProfile"
         component={UserProfileScreen}
-        options={{
-          headerShown: false,
-        }}
+        options={({ navigation }) => ({
+          headerShown: true,
+          title: '',
+          headerBackVisible: false,
+          headerLeft: () => <BackButton navigation={navigation} customOnPress={() => {
+            // Custom logic to skip diary screens
+            const state = navigation.getState();
+            const routes = state.routes;
+            const currentRouteIndex = state.index;
+            
+            // Look backwards in the route history to find the last non-diary screen
+            for (let i = currentRouteIndex - 1; i >= 0; i--) {
+              const route = routes[i];
+              if (route.name !== 'Diary' && route.name !== 'DiaryEntryDetails') {
+                // Found a non-diary screen, navigate back to it
+                navigation.navigate(route.name, route.params);
+                return;
+              }
+            }
+            
+            // If no non-diary screen found, use default back behavior
+            if (navigation.canGoBack()) {
+              navigation.goBack();
+            }
+          }} />,
+        })}
       />
       <HomeStack.Screen
         name="Followers"
         component={FollowersScreen}
-        options={{
-          headerShown: false,
-        }}
+        options={({ navigation }) => ({
+          headerShown: true,
+          title: '',
+          headerBackVisible: false,
+          headerLeft: () => <BackButton navigation={navigation} />,
+        })}
       />
       <HomeStack.Screen
         name="ListenedAlbums"
         component={ListenedAlbumsScreen}
-        options={{
-          headerShown: false,
-        }}
+        options={({ navigation }) => ({
+          headerShown: true,
+          title: '',
+          headerBackVisible: false,
+          headerLeft: () => <BackButton navigation={navigation} />,
+        })}
       />
       <HomeStack.Screen
         name="UserReviews"
         component={UserReviewsScreen}
-        options={{
-          headerShown: false,
-        }}
+        options={({ navigation }) => ({
+          headerShown: true,
+          title: '',
+          headerBackVisible: false,
+          headerLeft: () => <BackButton navigation={navigation} />,
+        })}
       />
       <HomeStack.Screen
         name="FavoriteAlbumsManagement"
@@ -178,60 +248,107 @@ function SearchStackNavigator() {
       <SearchStack.Screen
         name="PopularThisWeek"
         component={PopularThisWeekScreen}
-        options={{
-          headerShown: false,
-        }}
+        options={({ navigation }) => ({
+          headerShown: true,
+          title: '',
+          headerBackVisible: false,
+          headerLeft: () => <BackButton navigation={navigation} customOnPress={() => {
+            navigation.navigate('SearchMain');
+          }} />,
+        })}
       />
       <SearchStack.Screen
         name="NewFromFriends"
         component={NewFromFriendsScreen}
-        options={{
-          headerShown: false,
-        }}
+        options={({ navigation }) => ({
+          headerShown: true,
+          title: '',
+          headerBackVisible: false,
+          headerLeft: () => <BackButton navigation={navigation} customOnPress={() => {
+            navigation.navigate('SearchMain');
+          }} />,
+        })}
       />
       <SearchStack.Screen
         name="PopularWithFriends"
         component={PopularWithFriendsScreen}
-        options={{
-          headerShown: false,
-        }}
+        options={({ navigation }) => ({
+          headerShown: true,
+          title: '',
+          headerBackVisible: false,
+          headerLeft: () => <BackButton navigation={navigation} customOnPress={() => {
+            navigation.navigate('SearchMain');
+          }} />,
+        })}
       />
       <SearchStack.Screen
         name="AlbumDetails"
         component={AlbumDetailsScreen}
-        options={{
+        options={({ navigation }) => ({
           title: 'Album Details',
           headerBackVisible: false,
-          headerLeft: () => null,
-        }}
+          headerLeft: () => <BackButton navigation={navigation} />,
+        })}
       />
       <SearchStack.Screen
         name="UserProfile"
         component={UserProfileScreen}
-        options={{
-          headerShown: false,
-        }}
+        options={({ navigation }) => ({
+          headerShown: true,
+          title: '',
+          headerBackVisible: false,
+          headerLeft: () => <BackButton navigation={navigation} customOnPress={() => {
+            // Custom logic to skip diary screens
+            const state = navigation.getState();
+            const routes = state.routes;
+            const currentRouteIndex = state.index;
+            
+            // Look backwards in the route history to find the last non-diary screen
+            for (let i = currentRouteIndex - 1; i >= 0; i--) {
+              const route = routes[i];
+              if (route.name !== 'Diary' && route.name !== 'DiaryEntryDetails') {
+                // Found a non-diary screen, navigate back to it
+                navigation.navigate(route.name, route.params);
+                return;
+              }
+            }
+            
+            // If no non-diary screen found, use default back behavior
+            if (navigation.canGoBack()) {
+              navigation.goBack();
+            }
+          }} />,
+        })}
       />
       <SearchStack.Screen
         name="Followers"
         component={FollowersScreen}
-        options={{
-          headerShown: false,
-        }}
+        options={({ navigation }) => ({
+          headerShown: true,
+          title: '',
+          headerBackVisible: false,
+          headerLeft: () => <BackButton navigation={navigation} />,
+        })}
       />
       <SearchStack.Screen
         name="ListenedAlbums"
         component={ListenedAlbumsScreen}
-        options={{
-          headerShown: false,
-        }}
+        options={({ navigation }) => ({
+          headerShown: true,
+          title: '',
+          headerBackVisible: false,
+          headerLeft: () => <BackButton navigation={navigation} />,
+        })}
       />
       <SearchStack.Screen
         name="UserReviews"
         component={UserReviewsScreen}
-        options={{
-          headerShown: false,
-        }}
+        options={({ navigation }) => ({
+          headerShown: true,
+          title: '',
+          headerBackVisible: false,
+          headerLeft: () => <BackButton navigation={navigation} />,
+        })}
       />
       <SearchStack.Screen
         name="FavoriteAlbumsManagement"
@@ -275,60 +392,107 @@ function ProfileStackNavigator() {
       <ProfileStack.Screen
         name="PopularThisWeek"
         component={PopularThisWeekScreen}
-        options={{
-          headerShown: false,
-        }}
+        options={({ navigation }) => ({
+          headerShown: true,
+          title: '',
+          headerBackVisible: false,
+          headerLeft: () => <BackButton navigation={navigation} customOnPress={() => {
+            navigation.navigate('ProfileMain');
+          }} />,
+        })}
       />
       <ProfileStack.Screen
         name="NewFromFriends"
         component={NewFromFriendsScreen}
-        options={{
-          headerShown: false,
-        }}
+        options={({ navigation }) => ({
+          headerShown: true,
+          title: '',
+          headerBackVisible: false,
+          headerLeft: () => <BackButton navigation={navigation} customOnPress={() => {
+            navigation.navigate('ProfileMain');
+          }} />,
+        })}
       />
       <ProfileStack.Screen
         name="PopularWithFriends"
         component={PopularWithFriendsScreen}
-        options={{
-          headerShown: false,
-        }}
+        options={({ navigation }) => ({
+          headerShown: true,
+          title: '',
+          headerBackVisible: false,
+          headerLeft: () => <BackButton navigation={navigation} customOnPress={() => {
+            navigation.navigate('ProfileMain');
+          }} />,
+        })}
       />
       <ProfileStack.Screen
         name="AlbumDetails"
         component={AlbumDetailsScreen}
-        options={{
+        options={({ navigation }) => ({
           title: 'Album Details',
           headerBackVisible: false,
-          headerLeft: () => null,
-        }}
+          headerLeft: () => <BackButton navigation={navigation} />,
+        })}
       />
       <ProfileStack.Screen
         name="UserProfile"
         component={UserProfileScreen}
-        options={{
-          headerShown: false,
-        }}
+        options={({ navigation }) => ({
+          headerShown: true,
+          title: '',
+          headerBackVisible: false,
+          headerLeft: () => <BackButton navigation={navigation} customOnPress={() => {
+            // Custom logic to skip diary screens
+            const state = navigation.getState();
+            const routes = state.routes;
+            const currentRouteIndex = state.index;
+            
+            // Look backwards in the route history to find the last non-diary screen
+            for (let i = currentRouteIndex - 1; i >= 0; i--) {
+              const route = routes[i];
+              if (route.name !== 'Diary' && route.name !== 'DiaryEntryDetails') {
+                // Found a non-diary screen, navigate back to it
+                navigation.navigate(route.name, route.params);
+                return;
+              }
+            }
+            
+            // If no non-diary screen found, use default back behavior
+            if (navigation.canGoBack()) {
+              navigation.goBack();
+            }
+          }} />,
+        })}
       />
       <ProfileStack.Screen
         name="Followers"
         component={FollowersScreen}
-        options={{
-          headerShown: false,
-        }}
+        options={({ navigation }) => ({
+          headerShown: true,
+          title: '',
+          headerBackVisible: false,
+          headerLeft: () => <BackButton navigation={navigation} />,
+        })}
       />
       <ProfileStack.Screen
         name="ListenedAlbums"
         component={ListenedAlbumsScreen}
-        options={{
-          headerShown: false,
-        }}
+        options={({ navigation }) => ({
+          headerShown: true,
+          title: '',
+          headerBackVisible: false,
+          headerLeft: () => <BackButton navigation={navigation} />,
+        })}
       />
       <ProfileStack.Screen
         name="UserReviews"
         component={UserReviewsScreen}
-        options={{
-          headerShown: false,
-        }}
+        options={({ navigation }) => ({
+          headerShown: true,
+          title: '',
+          headerBackVisible: false,
+          headerLeft: () => <BackButton navigation={navigation} />,
+        })}
       />
       <ProfileStack.Screen
         name="FavoriteAlbumsManagement"

--- a/Musicboxd/src/navigation/AppNavigator.tsx
+++ b/Musicboxd/src/navigation/AppNavigator.tsx
@@ -106,7 +106,7 @@ function HomeStackNavigator() {
         component={PopularThisWeekScreen}
         options={({ navigation }) => ({
           headerShown: true,
-          title: '',
+          title: 'Popular This Week',
           headerBackVisible: false,
           headerLeft: () => <BackButton navigation={navigation} customOnPress={() => {
             navigation.goBack();
@@ -118,7 +118,7 @@ function HomeStackNavigator() {
         component={NewFromFriendsScreen}
         options={({ navigation }) => ({
           headerShown: true,
-          title: '',
+          title: 'New From Friends',
           headerBackVisible: false,
           headerLeft: () => <BackButton navigation={navigation} customOnPress={() => {
             navigation.goBack();
@@ -130,7 +130,7 @@ function HomeStackNavigator() {
         component={PopularWithFriendsScreen}
         options={({ navigation }) => ({
           headerShown: true,
-          title: '',
+          title: 'Popular With Friends',
           headerBackVisible: false,
           headerLeft: () => <BackButton navigation={navigation} customOnPress={() => {
             navigation.goBack();
@@ -253,7 +253,7 @@ function SearchStackNavigator() {
         component={PopularThisWeekScreen}
         options={({ navigation }) => ({
           headerShown: true,
-          title: '',
+          title: 'Popular This Week',
           headerBackVisible: false,
           headerLeft: () => <BackButton navigation={navigation} customOnPress={() => {
             navigation.goBack();
@@ -265,7 +265,7 @@ function SearchStackNavigator() {
         component={NewFromFriendsScreen}
         options={({ navigation }) => ({
           headerShown: true,
-          title: '',
+          title: 'New From Friends',
           headerBackVisible: false,
           headerLeft: () => <BackButton navigation={navigation} customOnPress={() => {
             navigation.goBack();
@@ -277,7 +277,7 @@ function SearchStackNavigator() {
         component={PopularWithFriendsScreen}
         options={({ navigation }) => ({
           headerShown: true,
-          title: '',
+          title: 'Popular With Friends',
           headerBackVisible: false,
           headerLeft: () => <BackButton navigation={navigation} customOnPress={() => {
             navigation.goBack();
@@ -400,7 +400,7 @@ function ProfileStackNavigator() {
         component={PopularThisWeekScreen}
         options={({ navigation }) => ({
           headerShown: true,
-          title: '',
+          title: 'Popular This Week',
           headerBackVisible: false,
           headerLeft: () => <BackButton navigation={navigation} customOnPress={() => {
             navigation.goBack();
@@ -412,7 +412,7 @@ function ProfileStackNavigator() {
         component={NewFromFriendsScreen}
         options={({ navigation }) => ({
           headerShown: true,
-          title: '',
+          title: 'New From Friends',
           headerBackVisible: false,
           headerLeft: () => <BackButton navigation={navigation} customOnPress={() => {
             navigation.goBack();
@@ -424,7 +424,7 @@ function ProfileStackNavigator() {
         component={PopularWithFriendsScreen}
         options={({ navigation }) => ({
           headerShown: true,
-          title: '',
+          title: 'Popular With Friends',
           headerBackVisible: false,
           headerLeft: () => <BackButton navigation={navigation} customOnPress={() => {
             navigation.goBack();

--- a/Musicboxd/src/navigation/AppNavigator.tsx
+++ b/Musicboxd/src/navigation/AppNavigator.tsx
@@ -159,19 +159,21 @@ function HomeStackNavigator() {
             const routes = state.routes;
             const currentRouteIndex = state.index;
             
-            // Look backwards in the route history to find the last non-diary screen
+            // Look backwards in the route history to find the last non-diary, non-userprofile screen
+            let foundValidRoute = false;
             for (let i = currentRouteIndex - 1; i >= 0; i--) {
               const route = routes[i];
-              if (route.name !== 'Diary' && route.name !== 'DiaryEntryDetails') {
-                // Found a non-diary screen, navigate back to it
+              if (route.name !== 'Diary' && route.name !== 'DiaryEntryDetails' && route.name !== 'UserProfile') {
+                // Found a valid non-diary, non-userprofile screen, navigate back to it
                 navigation.navigate(route.name, route.params);
+                foundValidRoute = true;
                 return;
               }
             }
             
-            // If no non-diary screen found, use default back behavior
-            if (navigation.canGoBack()) {
-              navigation.goBack();
+            // If no valid screen found, go to home
+            if (!foundValidRoute) {
+              navigation.navigate('HomeMain');
             }
           }} />,
         })}
@@ -306,19 +308,21 @@ function SearchStackNavigator() {
             const routes = state.routes;
             const currentRouteIndex = state.index;
             
-            // Look backwards in the route history to find the last non-diary screen
+            // Look backwards in the route history to find the last non-diary, non-userprofile screen
+            let foundValidRoute = false;
             for (let i = currentRouteIndex - 1; i >= 0; i--) {
               const route = routes[i];
-              if (route.name !== 'Diary' && route.name !== 'DiaryEntryDetails') {
-                // Found a non-diary screen, navigate back to it
+              if (route.name !== 'Diary' && route.name !== 'DiaryEntryDetails' && route.name !== 'UserProfile') {
+                // Found a valid non-diary, non-userprofile screen, navigate back to it
                 navigation.navigate(route.name, route.params);
+                foundValidRoute = true;
                 return;
               }
             }
             
-            // If no non-diary screen found, use default back behavior
-            if (navigation.canGoBack()) {
-              navigation.goBack();
+            // If no valid screen found, go to search main
+            if (!foundValidRoute) {
+              navigation.navigate('SearchMain');
             }
           }} />,
         })}
@@ -453,19 +457,21 @@ function ProfileStackNavigator() {
             const routes = state.routes;
             const currentRouteIndex = state.index;
             
-            // Look backwards in the route history to find the last non-diary screen
+            // Look backwards in the route history to find the last non-diary, non-userprofile screen
+            let foundValidRoute = false;
             for (let i = currentRouteIndex - 1; i >= 0; i--) {
               const route = routes[i];
-              if (route.name !== 'Diary' && route.name !== 'DiaryEntryDetails') {
-                // Found a non-diary screen, navigate back to it
+              if (route.name !== 'Diary' && route.name !== 'DiaryEntryDetails' && route.name !== 'UserProfile') {
+                // Found a valid non-diary, non-userprofile screen, navigate back to it
                 navigation.navigate(route.name, route.params);
+                foundValidRoute = true;
                 return;
               }
             }
             
-            // If no non-diary screen found, use default back behavior
-            if (navigation.canGoBack()) {
-              navigation.goBack();
+            // If no valid screen found, go to profile main
+            if (!foundValidRoute) {
+              navigation.navigate('ProfileMain');
             }
           }} />,
         })}

--- a/Musicboxd/src/navigation/AppNavigator.tsx
+++ b/Musicboxd/src/navigation/AppNavigator.tsx
@@ -209,9 +209,12 @@ function HomeStackNavigator() {
       <HomeStack.Screen
         name="FavoriteAlbumsManagement"
         component={FavoriteAlbumsManagementScreen}
-        options={{
-          headerShown: false,
-        }}
+        options={({ navigation }) => ({
+          headerShown: true,
+          title: '',
+          headerBackVisible: false,
+          headerLeft: () => <BackButton navigation={navigation} />,
+        })}
       />
       <HomeStack.Screen
         name="Diary"
@@ -353,9 +356,12 @@ function SearchStackNavigator() {
       <SearchStack.Screen
         name="FavoriteAlbumsManagement"
         component={FavoriteAlbumsManagementScreen}
-        options={{
-          headerShown: false,
-        }}
+        options={({ navigation }) => ({
+          headerShown: true,
+          title: '',
+          headerBackVisible: false,
+          headerLeft: () => <BackButton navigation={navigation} />,
+        })}
       />
       <SearchStack.Screen
         name="Diary"
@@ -497,9 +503,12 @@ function ProfileStackNavigator() {
       <ProfileStack.Screen
         name="FavoriteAlbumsManagement"
         component={FavoriteAlbumsManagementScreen}
-        options={{
-          headerShown: false,
-        }}
+        options={({ navigation }) => ({
+          headerShown: true,
+          title: '',
+          headerBackVisible: false,
+          headerLeft: () => <BackButton navigation={navigation} />,
+        })}
       />
       <ProfileStack.Screen
         name="Diary"

--- a/Musicboxd/src/screens/Home/NewFromFriendsScreen.tsx
+++ b/Musicboxd/src/screens/Home/NewFromFriendsScreen.tsx
@@ -166,13 +166,6 @@ export default function NewFromFriendsScreen() {
   return (
     <View style={styles.safeArea}>
       <View style={styles.container}>
-        {/* Header */}
-        <View style={styles.header}>
-          <Text variant="headlineMedium" style={styles.headerTitle}>
-            New From Friends
-          </Text>
-        </View>
-
         <ScrollView style={styles.scrollContainer} showsVerticalScrollIndicator={false}>
           <View style={styles.grid}>
             {activities.map((activity, index) => renderActivityCard(activity, index))}

--- a/Musicboxd/src/screens/Home/NewFromFriendsScreen.tsx
+++ b/Musicboxd/src/screens/Home/NewFromFriendsScreen.tsx
@@ -220,6 +220,7 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     flexWrap: 'wrap',
     paddingHorizontal: spacing.lg,
+    paddingTop: spacing.lg,
     paddingBottom: spacing.lg,
     justifyContent: 'space-between',
   },

--- a/Musicboxd/src/screens/Home/NewFromFriendsScreen.tsx
+++ b/Musicboxd/src/screens/Home/NewFromFriendsScreen.tsx
@@ -7,7 +7,7 @@ import {
   TouchableOpacity,
   Dimensions,
 } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
+// SafeAreaView import removed - using regular View since header handles safe area
 import { Text, ActivityIndicator, Avatar } from 'react-native-paper';
 import { useNavigation } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
@@ -164,7 +164,7 @@ export default function NewFromFriendsScreen() {
   }
 
   return (
-    <SafeAreaView style={styles.safeArea}>
+    <View style={styles.safeArea}>
       <View style={styles.container}>
         {/* Header */}
         <View style={styles.header}>
@@ -179,7 +179,7 @@ export default function NewFromFriendsScreen() {
           </View>
         </ScrollView>
       </View>
-    </SafeAreaView>
+    </View>
   );
 }
 

--- a/Musicboxd/src/screens/Home/PopularThisWeekScreen.tsx
+++ b/Musicboxd/src/screens/Home/PopularThisWeekScreen.tsx
@@ -89,13 +89,6 @@ export default function PopularThisWeekScreen() {
   return (
     <View style={styles.safeArea}>
       <View style={styles.container}>
-        {/* Header */}
-        <View style={styles.header}>
-          <Text variant="headlineMedium" style={styles.headerTitle}>
-            Popular This Week
-          </Text>
-        </View>
-
         <ScrollView style={styles.scrollContainer} showsVerticalScrollIndicator={false}>
           <View style={styles.grid}>
             {albums.map((album, index) => renderAlbumCard(album, index))}

--- a/Musicboxd/src/screens/Home/PopularThisWeekScreen.tsx
+++ b/Musicboxd/src/screens/Home/PopularThisWeekScreen.tsx
@@ -7,7 +7,7 @@ import {
   TouchableOpacity,
   Dimensions,
 } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
+// SafeAreaView import removed - using regular View since header handles safe area
 import { Text, ActivityIndicator } from 'react-native-paper';
 import { useNavigation } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
@@ -73,7 +73,7 @@ export default function PopularThisWeekScreen() {
 
   if (loading) {
     return (
-      <SafeAreaView style={styles.safeArea}>
+      <View style={styles.safeArea}>
         <View style={styles.container}>
           <View style={styles.loadingContainer}>
             <ActivityIndicator size="large" />
@@ -82,12 +82,12 @@ export default function PopularThisWeekScreen() {
             </Text>
           </View>
         </View>
-      </SafeAreaView>
+      </View>
     );
   }
 
   return (
-    <SafeAreaView style={styles.safeArea}>
+    <View style={styles.safeArea}>
       <View style={styles.container}>
         {/* Header */}
         <View style={styles.header}>
@@ -102,7 +102,7 @@ export default function PopularThisWeekScreen() {
           </View>
         </ScrollView>
       </View>
-    </SafeAreaView>
+    </View>
   );
 }
 

--- a/Musicboxd/src/screens/Home/PopularThisWeekScreen.tsx
+++ b/Musicboxd/src/screens/Home/PopularThisWeekScreen.tsx
@@ -143,6 +143,7 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     flexWrap: 'wrap',
     paddingHorizontal: spacing.lg,
+    paddingTop: spacing.lg,
     paddingBottom: spacing.lg,
     justifyContent: 'space-between',
   },

--- a/Musicboxd/src/screens/Home/PopularWithFriendsScreen.tsx
+++ b/Musicboxd/src/screens/Home/PopularWithFriendsScreen.tsx
@@ -7,7 +7,7 @@ import {
   TouchableOpacity,
   Dimensions,
 } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
+// SafeAreaView import removed - using regular View since header handles safe area
 import { Text, ActivityIndicator, Avatar } from 'react-native-paper';
 import { useNavigation } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
@@ -202,7 +202,7 @@ export default function PopularWithFriendsScreen() {
   }
 
   return (
-    <SafeAreaView style={styles.safeArea}>
+    <View style={styles.safeArea}>
       <View style={styles.container}>
         {/* Header */}
         <View style={styles.header}>
@@ -217,7 +217,7 @@ export default function PopularWithFriendsScreen() {
           </View>
         </ScrollView>
       </View>
-    </SafeAreaView>
+    </View>
   );
 }
 

--- a/Musicboxd/src/screens/Home/PopularWithFriendsScreen.tsx
+++ b/Musicboxd/src/screens/Home/PopularWithFriendsScreen.tsx
@@ -204,13 +204,6 @@ export default function PopularWithFriendsScreen() {
   return (
     <View style={styles.safeArea}>
       <View style={styles.container}>
-        {/* Header */}
-        <View style={styles.header}>
-          <Text variant="headlineMedium" style={styles.headerTitle}>
-            Popular With Friends
-          </Text>
-        </View>
-
         <ScrollView style={styles.scrollContainer} showsVerticalScrollIndicator={false}>
           <View style={styles.grid}>
             {albums.map((album, index) => renderAlbumCard(album, index))}

--- a/Musicboxd/src/screens/Home/PopularWithFriendsScreen.tsx
+++ b/Musicboxd/src/screens/Home/PopularWithFriendsScreen.tsx
@@ -258,6 +258,7 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     flexWrap: 'wrap',
     paddingHorizontal: spacing.lg,
+    paddingTop: spacing.lg,
     paddingBottom: spacing.lg,
     justifyContent: 'space-between',
   },

--- a/Musicboxd/src/screens/Profile/FavoriteAlbumsManagementScreen.tsx
+++ b/Musicboxd/src/screens/Profile/FavoriteAlbumsManagementScreen.tsx
@@ -7,7 +7,7 @@ import {
   TouchableOpacity,
   Dimensions,
 } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
+// SafeAreaView import removed - using regular View since header handles safe area
 import { Text, ActivityIndicator, Searchbar } from 'react-native-paper';
 import { useSelector, useDispatch } from 'react-redux';
 
@@ -196,7 +196,7 @@ export default function FavoriteAlbumsManagementScreen() {
   };
 
   return (
-    <SafeAreaView style={styles.safeArea}>
+    <View style={styles.safeArea}>
       {/* Header */}
       <View style={styles.header}>
         <Text variant="headlineMedium" style={styles.headerTitle}>
@@ -262,7 +262,7 @@ export default function FavoriteAlbumsManagementScreen() {
           </View>
         )}
       </ScrollView>
-    </SafeAreaView>
+    </View>
   );
 }
 

--- a/Musicboxd/src/screens/Profile/FollowersScreen.tsx
+++ b/Musicboxd/src/screens/Profile/FollowersScreen.tsx
@@ -5,7 +5,7 @@ import {
   StyleSheet,
   TouchableOpacity,
 } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
+// SafeAreaView import removed - using regular View since header handles safe area
 import {
   Text,
   Avatar,
@@ -150,7 +150,7 @@ export default function FollowersScreen() {
   const currentData = activeTab === 'followers' ? followers : followingUsers;
 
   return (
-    <SafeAreaView style={styles.safeArea}>
+    <View style={styles.safeArea}>
         {/* Header */}
   <View style={styles.header}>
     <Text variant="headlineSmall" style={styles.headerTitle}>
@@ -192,7 +192,7 @@ export default function FollowersScreen() {
           ListEmptyComponent={<EmptyState activeTab={activeTab} username={username} />}
         />
       )}
-    </SafeAreaView>
+    </View>
   );
 }
 

--- a/Musicboxd/src/screens/Profile/ListenedAlbumsScreen.tsx
+++ b/Musicboxd/src/screens/Profile/ListenedAlbumsScreen.tsx
@@ -7,7 +7,7 @@ import {
   Image,
   Dimensions,
 } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
+// SafeAreaView import removed - using regular View since header handles safe area
 import {
   Text,
   ActivityIndicator,
@@ -125,7 +125,7 @@ export default function ListenedAlbumsScreen() {
   }
 
   return (
-    <SafeAreaView style={styles.safeArea}>
+    <View style={styles.safeArea}>
       <View style={styles.container}>
         {/* Header */}
         <View style={styles.header}>
@@ -157,7 +157,7 @@ export default function ListenedAlbumsScreen() {
           </ScrollView>
         )}
       </View>
-    </SafeAreaView>
+    </View>
   );
 }
 

--- a/Musicboxd/src/screens/Profile/ProfileScreen.tsx
+++ b/Musicboxd/src/screens/Profile/ProfileScreen.tsx
@@ -9,7 +9,7 @@ import {
   useColorScheme,
 } from 'react-native';
 import { Text, Avatar, ActivityIndicator } from 'react-native-paper';
-import { SafeAreaView } from 'react-native-safe-area-context';
+// SafeAreaView import removed - using regular View since header handles safe area
 import { useNavigation } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
 import { useSelector, useDispatch } from 'react-redux';
@@ -329,7 +329,7 @@ export default function ProfileScreen() {
   }
 
   return (
-    <SafeAreaView style={styles.safeArea} edges={['left','right','bottom']}>
+    <View style={styles.safeArea}>
       {/* Segmented Control */}
       <View style={[styles.segmentHeader, { backgroundColor: currentTheme.colors.surface, borderBottomColor: theme.colors.border }]}> 
         <SegmentedButtons
@@ -441,7 +441,7 @@ export default function ProfileScreen() {
           </View>
         </View>
       </ScrollView>
-    </SafeAreaView>
+    </View>
   );
 }
 

--- a/Musicboxd/src/screens/Profile/UserProfileScreen.tsx
+++ b/Musicboxd/src/screens/Profile/UserProfileScreen.tsx
@@ -367,9 +367,6 @@ export default function UserProfileScreen() {
 
   return (
     <View style={styles.container}>
-            {/* Header */}
-      <View style={[styles.header, { paddingTop: insets.top }]} />
-
       {/* Segmented Control */}
       <View style={[styles.segmentHeader, { backgroundColor: currentTheme.colors.surface, borderBottomColor: theme.colors.border }]}>
         <SegmentedButtons

--- a/Musicboxd/src/screens/Profile/UserReviewsScreen.tsx
+++ b/Musicboxd/src/screens/Profile/UserReviewsScreen.tsx
@@ -6,7 +6,7 @@ import {
   TouchableOpacity,
   Image,
 } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
+// SafeAreaView import removed - using regular View since header handles safe area
 import {
   Text,
   ActivityIndicator,
@@ -147,7 +147,7 @@ export default function UserReviewsScreen() {
     : 0;
 
   return (
-    <SafeAreaView style={styles.safeArea}>
+    <View style={styles.safeArea}>
       {/* Header */}
       <View style={styles.header}>
         <View style={styles.headerContent}>
@@ -178,7 +178,7 @@ export default function UserReviewsScreen() {
           <View style={styles.bottomPadding} />
         </ScrollView>
       )}
-    </SafeAreaView>
+    </View>
   );
 }
 


### PR DESCRIPTION
Add back buttons to specified screens to improve navigation and user experience.

This PR implements back buttons on Album Details, Other User Profile, Albums Listened, Ratings, Following/Followers, Popular This Week, New From Friends, and Popular With Friends screens. A key aspect is the custom navigation logic for the 'Other user profile' screen, which now intelligently navigates back, skipping Diary and Diary Entry Details screens in the history as per requirements, ensuring a more intuitive user flow.

---
<a href="https://cursor.com/background-agent?bcId=bc-c2266acd-85b5-4b05-b6c4-44e23d7fe5c9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c2266acd-85b5-4b05-b6c4-44e23d7fe5c9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

