### PR TITLE
Remove average rating square from profile

### DIFF
--- a/Musicboxd/src/screens/Profile/ProfileScreen.tsx
+++ b/Musicboxd/src/screens/Profile/ProfileScreen.tsx
@@ -39,7 +39,6 @@ interface UserStats {
   albumsAllTime: number;
   ratingsThisYear: number;
   ratingsAllTime: number;
-  averageRating: number;
   followers: number;
   following: number;
 }
@@ -64,7 +63,6 @@ export default function ProfileScreen() {
     albumsAllTime: 0,
     ratingsThisYear: 0,
     ratingsAllTime: 0,
-    averageRating: 0,
     followers: 0,
     following: 0,
   });
@@ -181,7 +179,6 @@ export default function ProfileScreen() {
         albumsAllTime: stats.albumsAllTime,
         ratingsThisYear: stats.ratingsThisYear,
         ratingsAllTime: stats.ratingsAllTime,
-        averageRating: stats.averageRating,
         followers: stats.followers,
         following: stats.following,
       });
@@ -234,7 +231,6 @@ export default function ProfileScreen() {
       albumsAllTime: 0,
       ratingsThisYear: 0,
       ratingsAllTime: 0,
-      averageRating: 0,
       followers: 0,
       following: 0,
     });
@@ -468,7 +464,6 @@ export default function ProfileScreen() {
             {renderStatCard('Albums All Time', userStats.albumsAllTime, () => navigateToListenedAlbums('alltime'))}
             {renderStatCard('Ratings This Year', userStats.ratingsThisYear, () => navigateToUserReviews('year'))}
             {renderStatCard('Ratings All Time', userStats.ratingsAllTime, () => navigateToUserReviews('alltime'))}
-            {userStats.averageRating > 0 && renderStatCard('Average Rating', `★ ${userStats.averageRating.toFixed(1)}`, () => navigateToUserReviews('alltime'))}
             {renderStatCard('Followers', userStats.followers, navigateToFollowers)}
             {renderStatCard('Following', userStats.following, navigateToFollowing)}
           </View>


### PR DESCRIPTION
Remove the average rating square from the profile page to ensure a clean 2x3 grid layout.

---
<a href="https://cursor.com/background-agent?bcId=bc-f7de8b1c-1340-4e95-adf4-794acae7ff83">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f7de8b1c-1340-4e95-adf4-794acae7ff83">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

