### PR TITLE
add privacy policy webpage

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,192 @@
+# Resonare Privacy Policy - GitHub Pages
+
+This directory contains the privacy policy webpage for Resonare, hosted on GitHub Pages.
+
+## 📄 Files
+
+- `index.html` - The main privacy policy page with all content
+- `styles.css` - Responsive, modern CSS styling
+- `README.md` - This file
+
+## 🚀 GitHub Pages Setup
+
+### Initial Setup
+
+1. **Enable GitHub Pages**
+   - Go to your repository settings on GitHub
+   - Navigate to **Settings** > **Pages**
+   - Under "Source", select **main** branch
+   - Select **/docs** folder
+   - Click **Save**
+   - Wait 1-2 minutes for deployment
+
+2. **Verify Deployment**
+   - GitHub will provide your site URL (e.g., `https://jimmyshultz.github.io/musicboxd/`)
+   - Click the link to verify the privacy policy page loads correctly
+   - Ensure HTTPS is enabled (required by Apple App Store)
+
+3. **Test on Mobile**
+   - Open the URL on an iOS device
+   - Verify the page is responsive and readable
+   - Check that all sections display correctly
+
+## 🔗 Live URL
+
+Once deployed, your privacy policy will be available at:
+```
+https://[your-github-username].github.io/musicboxd/
+```
+
+Or with the full path:
+```
+https://[your-github-username].github.io/musicboxd/index.html
+```
+
+## 📱 Apple App Store Integration
+
+### Where to Add the Privacy Policy URL
+
+1. **App Store Connect**
+   - Log in to [App Store Connect](https://appstoreconnect.apple.com/)
+   - Select your app
+   - Go to **App Information**
+   - Add the privacy policy URL in the **Privacy Policy URL** field
+
+2. **App Privacy Details**
+   - In App Store Connect, go to **App Privacy**
+   - Complete the privacy questionnaire
+   - Ensure it matches the information in the privacy policy
+
+3. **Optional: In-App Link**
+   - Add a link to the privacy policy in your app's Settings screen
+   - Also consider adding it to the authentication flow
+
+## ✏️ Updating the Privacy Policy
+
+When you need to update the privacy policy:
+
+1. **Edit the HTML file**
+   ```bash
+   # Edit the file
+   vim docs/index.html  # or use your preferred editor
+   ```
+
+2. **Update the "Last Updated" date**
+   - Find the line with `<p class="last-updated">Last Updated: ...</p>`
+   - Change the date to the current date
+
+3. **Commit and push changes**
+   ```bash
+   git add docs/index.html
+   git commit -m "Update privacy policy"
+   git push origin main
+   ```
+
+4. **Wait for deployment**
+   - GitHub Pages will automatically rebuild (takes 1-2 minutes)
+   - Verify changes are live by visiting the URL
+
+## 📧 Contact Email
+
+**Important:** Make sure to update the contact email in `index.html` before going live:
+
+- Find: `privacy@resonare.app`
+- Replace with your actual privacy contact email address
+
+## ✅ Pre-Launch Checklist
+
+Before submitting to the App Store, verify:
+
+- [ ] Privacy policy URL is publicly accessible
+- [ ] HTTPS is enabled (green lock icon in browser)
+- [ ] Page loads correctly on mobile devices (iOS)
+- [ ] Contact email is correct and active
+- [ ] "Last Updated" date is accurate
+- [ ] All sections accurately reflect your data practices
+- [ ] Third-party service links work correctly
+- [ ] No placeholder text remains
+
+## 🎨 Customization
+
+### Updating Styles
+
+To customize the appearance:
+
+1. Edit `styles.css`
+2. Modify CSS variables at the top of the file:
+   ```css
+   :root {
+       --primary-color: #6200ee;  /* Change to your app's primary color */
+       --accent-color: #03dac6;   /* Change to your app's accent color */
+   }
+   ```
+
+### Dark Mode
+
+The privacy policy automatically supports dark mode based on user preferences. No additional configuration needed.
+
+## 🔍 Testing
+
+### Browser Testing
+
+Test in these browsers to ensure compatibility:
+- Safari (iOS and macOS)
+- Chrome
+- Firefox
+- Edge
+
+### Mobile Testing
+
+Test on actual iOS devices:
+- iPhone (various sizes)
+- iPad
+- Test in both portrait and landscape orientations
+
+### Accessibility Testing
+
+- Test with VoiceOver (iOS) or screen readers
+- Ensure all links are keyboard accessible
+- Verify color contrast meets WCAG AA standards
+
+## 📝 Version History
+
+Track changes to your privacy policy using Git:
+
+```bash
+# View history
+git log docs/index.html
+
+# View specific change
+git show <commit-hash>
+```
+
+## 🆘 Troubleshooting
+
+### Page Not Loading
+
+1. Check GitHub Pages settings are correct
+2. Ensure the `docs/` folder is on the `main` branch
+3. Wait 5 minutes and try again (deployment can take time)
+4. Check GitHub Actions tab for deployment status
+
+### 404 Error
+
+1. Verify the files are in the `docs/` folder at repository root
+2. Check file names are exactly `index.html` and `styles.css`
+3. Ensure GitHub Pages is enabled and set to serve from `/docs`
+
+### Styling Not Working
+
+1. Verify `styles.css` is in the same directory as `index.html`
+2. Check the `<link>` tag in `index.html` is correct
+3. Hard refresh the page (Cmd+Shift+R on Mac, Ctrl+Shift+R on Windows)
+
+## 📚 Resources
+
+- [GitHub Pages Documentation](https://docs.github.com/en/pages)
+- [Apple App Store Review Guidelines](https://developer.apple.com/app-store/review/guidelines/)
+- [App Privacy Details on App Store](https://developer.apple.com/app-store/app-privacy-details/)
+
+---
+
+**Last Updated:** December 7, 2025

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,362 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Privacy Policy for Resonare - A social music discovery app for iOS">
+    <meta name="author" content="Resonare">
+    <title>Privacy Policy - Resonare</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+    <div class="container">
+        <header>
+            <h1>Privacy Policy</h1>
+            <p class="app-name">Resonare</p>
+            <p class="last-updated">Last Updated: December 7, 2025</p>
+        </header>
+
+        <main>
+            <section id="introduction">
+                <h2>Introduction</h2>
+                <p>
+                    Welcome to Resonare, a social music discovery app that helps you track, rate, and share your album listening experiences. 
+                    This Privacy Policy explains how we collect, use, disclose, and safeguard your information when you use our mobile application.
+                </p>
+                <p>
+                    Please read this privacy policy carefully. If you do not agree with the terms of this privacy policy, please do not access the application.
+                </p>
+            </section>
+
+            <section id="information-we-collect">
+                <h2>1. Information We Collect</h2>
+                <p>We collect information that you provide directly to us and information that is automatically collected when you use our app.</p>
+
+                <h3>1.1 Personal Information</h3>
+                <ul>
+                    <li><strong>Account Information:</strong> When you create an account using Google Sign-In or Apple Sign-In, we collect your email address and name.</li>
+                    <li><strong>Profile Information:</strong> Display name, profile picture (if you choose to upload one), and bio information.</li>
+                    <li><strong>User Content:</strong> Album ratings, listening dates, diary entries, and reviews you create within the app.</li>
+                    <li><strong>Social Information:</strong> Your follow relationships (who you follow and who follows you), activity visibility preferences, and social interactions within the app.</li>
+                </ul>
+
+                <h3>1.2 Music Activity Data</h3>
+                <ul>
+                    <li>Albums you mark as listened</li>
+                    <li>Ratings you provide for albums (1-5 stars)</li>
+                    <li>Dates when you listened to albums</li>
+                    <li>Personal notes and diary entries about albums</li>
+                    <li>Your listening statistics and history</li>
+                </ul>
+
+                <h3>1.3 Technical Data</h3>
+                <ul>
+                    <li><strong>Crash Reports:</strong> We collect crash logs and error reports through Firebase Crashlytics to help us identify and fix bugs.</li>
+                    <li><strong>Usage Analytics:</strong> Basic information about how you use the app to help us improve features and performance.</li>
+                </ul>
+
+                <h3>1.4 Information We Do NOT Collect</h3>
+                <ul>
+                    <li>Location data or GPS coordinates</li>
+                    <li>Device identifiers for advertising purposes</li>
+                    <li>Access to your Spotify listening history or playlists</li>
+                    <li>Browsing history outside the app</li>
+                    <li>Contact lists or phone book data</li>
+                    <li>Payment information (app is currently free)</li>
+                </ul>
+            </section>
+
+            <section id="how-we-use-information">
+                <h2>2. How We Use Your Information</h2>
+                <p>We use the information we collect for the following purposes:</p>
+
+                <h3>2.1 Core App Functionality</h3>
+                <ul>
+                    <li>Create and manage your user account</li>
+                    <li>Store and display your music listening history</li>
+                    <li>Enable you to rate and review albums</li>
+                    <li>Facilitate social features like following other users</li>
+                    <li>Display personalized content and recommendations</li>
+                </ul>
+
+                <h3>2.2 App Improvement</h3>
+                <ul>
+                    <li>Monitor and analyze usage patterns to improve app performance</li>
+                    <li>Identify and fix bugs and technical issues</li>
+                    <li>Develop new features based on user behavior</li>
+                    <li>Optimize user experience and interface design</li>
+                </ul>
+
+                <h3>2.3 Communication</h3>
+                <ul>
+                    <li>Respond to your questions and support requests</li>
+                    <li>Send you important updates about the app</li>
+                    <li>Notify you about changes to our privacy policy</li>
+                </ul>
+
+                <h3>2.4 What We DON'T Do</h3>
+                <ul>
+                    <li>We do not sell your personal information to third parties</li>
+                    <li>We do not use your data for advertising purposes</li>
+                    <li>We do not share your listening history with music services</li>
+                    <li>We do not track you across other apps or websites</li>
+                </ul>
+            </section>
+
+            <section id="third-party-services">
+                <h2>3. Third-Party Services</h2>
+                <p>We use the following third-party services to provide and improve our app. Each service has its own privacy policy governing how they handle your data.</p>
+
+                <h3>3.1 Authentication Services</h3>
+                <div class="service-card">
+                    <h4>Google Sign-In</h4>
+                    <p>Used for user authentication. We only receive your email address and name from Google.</p>
+                    <p><a href="https://policies.google.com/privacy" target="_blank" rel="noopener">Google Privacy Policy</a></p>
+                </div>
+
+                <div class="service-card">
+                    <h4>Apple Sign-In</h4>
+                    <p>Used for user authentication on iOS devices. We only receive basic profile information.</p>
+                    <p><a href="https://www.apple.com/legal/privacy/" target="_blank" rel="noopener">Apple Privacy Policy</a></p>
+                </div>
+
+                <h3>3.2 Backend Infrastructure</h3>
+                <div class="service-card">
+                    <h4>Supabase</h4>
+                    <p>Our backend database and authentication provider. Stores all user data, album information, and social connections securely.</p>
+                    <p><a href="https://supabase.com/privacy" target="_blank" rel="noopener">Supabase Privacy Policy</a></p>
+                </div>
+
+                <h3>3.3 App Stability</h3>
+                <div class="service-card">
+                    <h4>Firebase Crashlytics</h4>
+                    <p>Collects crash reports and error logs to help us identify and fix bugs that cause the app to crash.</p>
+                    <p><a href="https://firebase.google.com/support/privacy" target="_blank" rel="noopener">Firebase Privacy Policy</a></p>
+                </div>
+
+                <h3>3.4 Music Data</h3>
+                <div class="service-card">
+                    <h4>Spotify Web API</h4>
+                    <p>Provides album metadata, artwork, and track listings. We do not access your Spotify account or listening history.</p>
+                    <p><a href="https://www.spotify.com/privacy" target="_blank" rel="noopener">Spotify Privacy Policy</a></p>
+                </div>
+            </section>
+
+            <section id="data-sharing">
+                <h2>4. Data Sharing and Disclosure</h2>
+                
+                <h3>4.1 What We Share</h3>
+                <p>We only share your information in the following limited circumstances:</p>
+                <ul>
+                    <li><strong>With Other Users:</strong> Your profile information, album ratings, and activity are visible to other users based on your privacy settings (public or private profile).</li>
+                    <li><strong>Service Providers:</strong> We share data with Supabase (backend hosting) and Firebase (crash reporting) to operate the app.</li>
+                    <li><strong>Legal Requirements:</strong> We may disclose information if required by law or to protect our rights and safety.</li>
+                </ul>
+
+                <h3>4.2 What We Don't Share</h3>
+                <ul>
+                    <li>We do not sell your personal information to advertisers or data brokers</li>
+                    <li>We do not share your data for advertising or marketing purposes</li>
+                    <li>We do not provide your listening history to music services or labels</li>
+                    <li>We do not share your data with analytics companies beyond crash reporting</li>
+                </ul>
+
+                <h3>4.3 Social Features</h3>
+                <p>
+                    Resonare is a social app, which means certain information is shared with other users:
+                </p>
+                <ul>
+                    <li><strong>Public Profiles:</strong> Your profile, ratings, and activity are visible to all users</li>
+                    <li><strong>Private Profiles:</strong> Your profile is discoverable, but content is only visible to approved followers</li>
+                    <li><strong>Activity Feeds:</strong> Users who follow you can see your recent album ratings and reviews</li>
+                </ul>
+            </section>
+
+            <section id="user-rights">
+                <h2>5. Your Rights and Choices</h2>
+                
+                <h3>5.1 Privacy Controls</h3>
+                <ul>
+                    <li><strong>Profile Privacy:</strong> Set your profile to public or private in app settings</li>
+                    <li><strong>Follow Requests:</strong> Approve or deny follow requests for private profiles</li>
+                    <li><strong>Activity Visibility:</strong> Control what appears in your activity feed</li>
+                </ul>
+
+                <h3>5.2 Account Management</h3>
+                <ul>
+                    <li><strong>Edit Profile:</strong> Update your display name, profile picture, and bio at any time</li>
+                    <li><strong>Delete Content:</strong> Remove individual ratings, reviews, or diary entries</li>
+                    <li><strong>Export Data:</strong> Request a copy of your data by contacting us</li>
+                    <li><strong>Delete Account:</strong> Permanently delete your account and all associated data through app settings or by contacting us</li>
+                </ul>
+
+                <h3>5.3 Data Portability</h3>
+                <p>
+                    You have the right to receive a copy of your personal data in a structured, machine-readable format. 
+                    Contact us to request data export.
+                </p>
+
+                <h3>5.4 Rights Under GDPR (European Users)</h3>
+                <p>If you are located in the European Economic Area, you have additional rights including:</p>
+                <ul>
+                    <li>Right to access your personal data</li>
+                    <li>Right to rectification of inaccurate data</li>
+                    <li>Right to erasure ("right to be forgotten")</li>
+                    <li>Right to restrict processing</li>
+                    <li>Right to data portability</li>
+                    <li>Right to object to processing</li>
+                </ul>
+
+                <h3>5.5 Rights Under CCPA (California Residents)</h3>
+                <p>California residents have the right to:</p>
+                <ul>
+                    <li>Know what personal information is collected</li>
+                    <li>Know whether personal information is sold or disclosed</li>
+                    <li>Access personal information</li>
+                    <li>Request deletion of personal information</li>
+                    <li>Opt-out of the sale of personal information (we do not sell data)</li>
+                </ul>
+            </section>
+
+            <section id="data-security">
+                <h2>6. Data Security</h2>
+                <p>
+                    We take the security of your personal information seriously and implement industry-standard security measures:
+                </p>
+
+                <h3>6.1 Technical Safeguards</h3>
+                <ul>
+                    <li><strong>Encryption:</strong> All data is encrypted in transit using HTTPS/TLS and at rest in our database</li>
+                    <li><strong>Row-Level Security:</strong> Database policies ensure users can only access their own data and data they're authorized to see</li>
+                    <li><strong>Secure Authentication:</strong> OAuth 2.0 authentication with Google and Apple</li>
+                    <li><strong>Access Controls:</strong> Limited employee access to user data on a need-to-know basis</li>
+                </ul>
+
+                <h3>6.2 Organizational Safeguards</h3>
+                <ul>
+                    <li>Regular security audits and updates</li>
+                    <li>Secure development practices</li>
+                    <li>Third-party security certifications (Supabase SOC 2 Type II compliant)</li>
+                </ul>
+
+                <h3>6.3 Data Breach Response</h3>
+                <p>
+                    In the unlikely event of a data breach affecting your personal information, we will notify you 
+                    within 72 hours via email and provide information about the breach and steps you can take to protect yourself.
+                </p>
+            </section>
+
+            <section id="data-retention">
+                <h2>7. Data Retention</h2>
+                <p>We retain your information for as long as your account is active or as needed to provide services:</p>
+                <ul>
+                    <li><strong>Account Data:</strong> Retained until you delete your account</li>
+                    <li><strong>Listening History:</strong> Retained until you delete specific entries or your entire account</li>
+                    <li><strong>Crash Reports:</strong> Retained for 90 days for debugging purposes</li>
+                    <li><strong>Deleted Accounts:</strong> All personal data is permanently deleted within 30 days of account deletion</li>
+                </ul>
+                <p>
+                    Some data may be retained for longer periods where required by law or for legitimate business purposes 
+                    (e.g., resolving disputes, enforcing agreements).
+                </p>
+            </section>
+
+            <section id="childrens-privacy">
+                <h2>8. Children's Privacy</h2>
+                <p>
+                    Resonare is not intended for children under the age of 13. We do not knowingly collect personal information 
+                    from children under 13 years of age. If you are under 13, please do not use this app or provide any information to us.
+                </p>
+                <p>
+                    If we learn that we have collected personal information from a child under 13 without parental consent, 
+                    we will take steps to delete that information as quickly as possible.
+                </p>
+                <p>
+                    If you believe we have collected information from a child under 13, please contact us immediately.
+                </p>
+            </section>
+
+            <section id="international-data-transfers">
+                <h2>9. International Data Transfers</h2>
+                <p>
+                    Your information may be transferred to and processed in countries other than your country of residence. 
+                    These countries may have data protection laws different from those in your country.
+                </p>
+                <p>
+                    We use Supabase for data storage, which hosts data in secure facilities. When we transfer data internationally, 
+                    we ensure appropriate safeguards are in place to protect your information.
+                </p>
+            </section>
+
+            <section id="changes-to-policy">
+                <h2>10. Changes to This Privacy Policy</h2>
+                <p>
+                    We may update this privacy policy from time to time to reflect changes in our practices or for legal, 
+                    operational, or regulatory reasons.
+                </p>
+                <p>
+                    When we make changes, we will:
+                </p>
+                <ul>
+                    <li>Update the "Last Updated" date at the top of this policy</li>
+                    <li>Notify you through the app or via email if changes are material</li>
+                    <li>Give you the opportunity to review the changes before they take effect</li>
+                </ul>
+                <p>
+                    We encourage you to review this privacy policy periodically. Your continued use of the app after changes 
+                    are posted constitutes your acceptance of the updated policy.
+                </p>
+            </section>
+
+            <section id="contact">
+                <h2>11. Contact Information</h2>
+                <p>
+                    If you have questions, concerns, or requests regarding this privacy policy or our data practices, 
+                    please contact us:
+                </p>
+                <div class="contact-info">
+                    <p><strong>Email:</strong> <a href="mailto:jimmyshultz3@gmail.com">jimmyshultz3@gmail.com</a></p>
+                    <p><strong>Response Time:</strong> We aim to respond to all inquiries within 48 hours</p>
+                </div>
+                <p>
+                    For data access, deletion, or portability requests, please include "Data Request" in your email subject line 
+                    and provide your registered email address for verification.
+                </p>
+            </section>
+
+            <section id="additional-information">
+                <h2>12. Additional Information</h2>
+                
+                <h3>12.1 Do Not Track</h3>
+                <p>
+                    Some web browsers have a "Do Not Track" feature. Because there is not yet a common understanding of how to 
+                    interpret Do Not Track signals, our app does not currently respond to Do Not Track signals.
+                </p>
+
+                <h3>12.2 Third-Party Links</h3>
+                <p>
+                    Our app may contain links to third-party websites or services (such as Spotify album pages). 
+                    We are not responsible for the privacy practices of these third parties. We encourage you to read 
+                    their privacy policies.
+                </p>
+
+                <h3>12.3 Open Source</h3>
+                <p>
+                    Resonare uses open-source libraries and frameworks. For a complete list of third-party code used in the app, 
+                    please see our acknowledgments section within the app.
+                </p>
+            </section>
+        </main>
+
+        <footer>
+            <div class="footer-content">
+                <p>&copy; 2025 Resonare. All rights reserved.</p>
+                <p class="footer-links">
+                    <a href="https://github.com/jimmyshultz/musicboxd" target="_blank" rel="noopener">GitHub</a>
+                </p>
+                <p class="version">Privacy Policy Version 1.0 | Effective Date: December 7, 2025</p>
+            </div>
+        </footer>
+    </div>
+</body>
+</html>

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -1,0 +1,444 @@
+/* ============================================
+   Resonare Privacy Policy Styles
+   Modern, responsive, and accessible design
+   ============================================ */
+
+/* CSS Variables for theming */
+:root {
+    --primary-color: #6200ee;
+    --primary-dark: #3700b3;
+    --accent-color: #03dac6;
+    --background: #ffffff;
+    --surface: #f5f5f5;
+    --text-primary: #000000;
+    --text-secondary: #666666;
+    --border-color: #e0e0e0;
+    --link-color: #6200ee;
+    --link-hover: #3700b3;
+    --shadow: rgba(0, 0, 0, 0.1);
+    
+    /* Typography */
+    --font-body: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    --font-heading: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    
+    /* Spacing */
+    --spacing-xs: 0.5rem;
+    --spacing-sm: 1rem;
+    --spacing-md: 1.5rem;
+    --spacing-lg: 2rem;
+    --spacing-xl: 3rem;
+    
+    /* Border radius */
+    --radius-sm: 4px;
+    --radius-md: 8px;
+    --radius-lg: 12px;
+}
+
+/* Dark mode support */
+@media (prefers-color-scheme: dark) {
+    :root {
+        --background: #121212;
+        --surface: #1e1e1e;
+        --text-primary: #ffffff;
+        --text-secondary: #b0b0b0;
+        --border-color: #333333;
+        --shadow: rgba(255, 255, 255, 0.05);
+    }
+}
+
+/* ============================================
+   Base Styles
+   ============================================ */
+
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+html {
+    scroll-behavior: smooth;
+    font-size: 16px;
+}
+
+body {
+    font-family: var(--font-body);
+    line-height: 1.6;
+    color: var(--text-primary);
+    background-color: var(--background);
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+}
+
+/* ============================================
+   Container & Layout
+   ============================================ */
+
+.container {
+    max-width: 800px;
+    margin: 0 auto;
+    padding: var(--spacing-lg) var(--spacing-md);
+}
+
+@media (max-width: 768px) {
+    .container {
+        padding: var(--spacing-md) var(--spacing-sm);
+    }
+}
+
+/* ============================================
+   Header
+   ============================================ */
+
+header {
+    text-align: center;
+    margin-bottom: var(--spacing-xl);
+    padding-bottom: var(--spacing-lg);
+    border-bottom: 2px solid var(--border-color);
+}
+
+header h1 {
+    font-family: var(--font-heading);
+    font-size: 2.5rem;
+    font-weight: 700;
+    color: var(--primary-color);
+    margin-bottom: var(--spacing-sm);
+}
+
+.app-name {
+    font-size: 1.25rem;
+    font-weight: 600;
+    color: var(--text-secondary);
+    margin-bottom: var(--spacing-xs);
+}
+
+.last-updated {
+    font-size: 0.875rem;
+    color: var(--text-secondary);
+    font-style: italic;
+}
+
+@media (max-width: 768px) {
+    header h1 {
+        font-size: 2rem;
+    }
+    
+    .app-name {
+        font-size: 1.125rem;
+    }
+}
+
+/* ============================================
+   Typography
+   ============================================ */
+
+h2 {
+    font-family: var(--font-heading);
+    font-size: 1.75rem;
+    font-weight: 700;
+    color: var(--text-primary);
+    margin-top: var(--spacing-xl);
+    margin-bottom: var(--spacing-md);
+    padding-bottom: var(--spacing-xs);
+    border-bottom: 1px solid var(--border-color);
+}
+
+h3 {
+    font-family: var(--font-heading);
+    font-size: 1.375rem;
+    font-weight: 600;
+    color: var(--text-primary);
+    margin-top: var(--spacing-lg);
+    margin-bottom: var(--spacing-sm);
+}
+
+h4 {
+    font-family: var(--font-heading);
+    font-size: 1.125rem;
+    font-weight: 600;
+    color: var(--primary-color);
+    margin-bottom: var(--spacing-xs);
+}
+
+p {
+    margin-bottom: var(--spacing-md);
+    color: var(--text-primary);
+}
+
+strong {
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+@media (max-width: 768px) {
+    h2 {
+        font-size: 1.5rem;
+    }
+    
+    h3 {
+        font-size: 1.25rem;
+    }
+    
+    h4 {
+        font-size: 1.125rem;
+    }
+}
+
+/* ============================================
+   Sections
+   ============================================ */
+
+section {
+    margin-bottom: var(--spacing-xl);
+}
+
+section:first-of-type {
+    margin-top: 0;
+}
+
+/* ============================================
+   Lists
+   ============================================ */
+
+ul {
+    list-style-position: outside;
+    margin-left: var(--spacing-lg);
+    margin-bottom: var(--spacing-md);
+}
+
+ul li {
+    margin-bottom: var(--spacing-sm);
+    color: var(--text-primary);
+    line-height: 1.7;
+}
+
+ul ul {
+    margin-top: var(--spacing-sm);
+    margin-bottom: var(--spacing-sm);
+}
+
+@media (max-width: 768px) {
+    ul {
+        margin-left: var(--spacing-md);
+    }
+}
+
+/* ============================================
+   Links
+   ============================================ */
+
+a {
+    color: var(--link-color);
+    text-decoration: none;
+    border-bottom: 1px solid transparent;
+    transition: all 0.2s ease;
+}
+
+a:hover {
+    color: var(--link-hover);
+    border-bottom-color: var(--link-hover);
+}
+
+a:focus {
+    outline: 2px solid var(--primary-color);
+    outline-offset: 2px;
+    border-radius: var(--radius-sm);
+}
+
+/* ============================================
+   Service Cards
+   ============================================ */
+
+.service-card {
+    background-color: var(--surface);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-md);
+    padding: var(--spacing-md);
+    margin-bottom: var(--spacing-md);
+    box-shadow: 0 2px 4px var(--shadow);
+}
+
+.service-card h4 {
+    margin-top: 0;
+}
+
+.service-card p {
+    margin-bottom: var(--spacing-sm);
+}
+
+.service-card p:last-child {
+    margin-bottom: 0;
+}
+
+/* ============================================
+   Contact Information
+   ============================================ */
+
+.contact-info {
+    background-color: var(--surface);
+    border-left: 4px solid var(--primary-color);
+    padding: var(--spacing-md);
+    border-radius: var(--radius-sm);
+    margin: var(--spacing-md) 0;
+}
+
+.contact-info p {
+    margin-bottom: var(--spacing-xs);
+}
+
+.contact-info p:last-child {
+    margin-bottom: 0;
+}
+
+/* ============================================
+   Footer
+   ============================================ */
+
+footer {
+    margin-top: var(--spacing-xl);
+    padding-top: var(--spacing-lg);
+    border-top: 2px solid var(--border-color);
+    text-align: center;
+}
+
+.footer-content {
+    color: var(--text-secondary);
+}
+
+.footer-content p {
+    margin-bottom: var(--spacing-sm);
+    font-size: 0.875rem;
+}
+
+.footer-links {
+    margin: var(--spacing-sm) 0;
+}
+
+.footer-links a {
+    margin: 0 var(--spacing-sm);
+    color: var(--text-secondary);
+}
+
+.footer-links a:hover {
+    color: var(--primary-color);
+}
+
+.version {
+    font-size: 0.75rem;
+    color: var(--text-secondary);
+    opacity: 0.7;
+}
+
+/* ============================================
+   Responsive Design
+   ============================================ */
+
+@media (max-width: 480px) {
+    html {
+        font-size: 14px;
+    }
+    
+    .container {
+        padding: var(--spacing-sm);
+    }
+    
+    header {
+        margin-bottom: var(--spacing-lg);
+    }
+    
+    section {
+        margin-bottom: var(--spacing-lg);
+    }
+}
+
+/* ============================================
+   Print Styles
+   ============================================ */
+
+@media print {
+    * {
+        background: white !important;
+        color: black !important;
+        box-shadow: none !important;
+        text-shadow: none !important;
+    }
+    
+    body {
+        font-size: 12pt;
+        line-height: 1.5;
+    }
+    
+    header, footer {
+        border-color: #000 !important;
+    }
+    
+    h2, h3, h4 {
+        page-break-after: avoid;
+    }
+    
+    ul, p {
+        page-break-inside: avoid;
+    }
+    
+    a {
+        text-decoration: underline;
+    }
+    
+    a[href^="http"]:after {
+        content: " (" attr(href) ")";
+        font-size: 90%;
+    }
+    
+    .service-card {
+        border: 1pt solid #000;
+        page-break-inside: avoid;
+    }
+}
+
+/* ============================================
+   Accessibility Enhancements
+   ============================================ */
+
+/* Focus visible for keyboard navigation */
+:focus-visible {
+    outline: 2px solid var(--primary-color);
+    outline-offset: 2px;
+}
+
+/* Reduced motion for users who prefer it */
+@media (prefers-reduced-motion: reduce) {
+    * {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+        scroll-behavior: auto !important;
+    }
+}
+
+/* High contrast mode support */
+@media (prefers-contrast: high) {
+    :root {
+        --primary-color: #0000ee;
+        --border-color: #000000;
+    }
+    
+    a {
+        text-decoration: underline;
+    }
+}
+
+/* ============================================
+   Utility Classes
+   ============================================ */
+
+.text-center {
+    text-align: center;
+}
+
+.mt-0 {
+    margin-top: 0;
+}
+
+.mb-0 {
+    margin-bottom: 0;
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a static, responsive privacy policy webpage with styles and a README for GitHub Pages deployment and maintenance.
> 
> - **Website/Docs**:
>   - **`docs/index.html`**: Adds full privacy policy page (data collection/use, third-party services, sharing, user rights, security, retention, children's privacy, international transfers, changes, contact, additional info).
>   - **`docs/styles.css`**: Implements responsive design with dark mode, accessibility, and print styles.
>   - **`docs/README.md`**: Provides GitHub Pages setup, App Store integration, update workflow, customization, testing, and troubleshooting guidance.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e16a7faddade14f2935303b15ba77289889ab488. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->