### PR TITLE
deps: redux/supabase minor bumps + actions/checkout v7

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -30,7 +30,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/Resonare/package-lock.json
+++ b/Resonare/package-lock.json
@@ -21,8 +21,8 @@
         "@react-navigation/bottom-tabs": "^7.18.8",
         "@react-navigation/native": "^7.3.8",
         "@react-navigation/stack": "^7.10.11",
-        "@reduxjs/toolkit": "^2.11.2",
-        "@supabase/supabase-js": "^2.109.0",
+        "@reduxjs/toolkit": "^2.12.0",
+        "@supabase/supabase-js": "^2.110.3",
         "@types/lodash": "^4.17.24",
         "@types/react-native-vector-icons": "^6.4.18",
         "bad-words": "^4.0.0",
@@ -46,7 +46,7 @@
         "react-native-view-shot": "^4.0.3",
         "react-native-webview": "^13.16.0",
         "react-native-worklets": "^0.7.1",
-        "react-redux": "^9.2.0"
+        "react-redux": "^9.3.0"
       },
       "devDependencies": {
         "@babel/core": "^7.29.7",
@@ -6437,9 +6437,9 @@
       }
     },
     "node_modules/@reduxjs/toolkit": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
-      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.12.0.tgz",
+      "integrity": "sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==",
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
@@ -6523,27 +6523,27 @@
       "license": "MIT"
     },
     "node_modules/@supabase/auth-js": {
-      "version": "2.109.0",
-      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.109.0.tgz",
-      "integrity": "sha512-krf61vksi92kEUYtNH70GnIMOoQqLBAKG2e3Aha4e/0uJA6i1OWCxL7WUGHo6c0Vu/w96Y1DdnkYz0NOg0kYog==",
+      "version": "2.110.3",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.110.3.tgz",
+      "integrity": "sha512-aUPKlhOtJtH04sVcppDKeOlgIw28aQ4NqtnhwlkmbIbqNACpH5By+PNJyhiHkY17tBWGID70GIaQ96Fi8M/h8A==",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.1"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@supabase/functions-js": {
-      "version": "2.109.0",
-      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.109.0.tgz",
-      "integrity": "sha512-IiwAspZrVrBRYQoFgSJvkcA9iJvTCw8nHOdvlKARDushlw/x1YY3YJYtwwgZFtl7utUbTiZ5SwohXPNgnpZM+g==",
+      "version": "2.110.3",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.110.3.tgz",
+      "integrity": "sha512-jT4kLSRuKVYGt/xY1z1N1HSuq5DeCZHIHkDsChaqcBRUDcDIG2VhPHeD0FbP+AwMy+KpGw7KfZ6jICdWlN+mmQ==",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.1"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@supabase/phoenix": {
@@ -6553,57 +6553,57 @@
       "license": "MIT"
     },
     "node_modules/@supabase/postgrest-js": {
-      "version": "2.109.0",
-      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.109.0.tgz",
-      "integrity": "sha512-Xk4gzuzyrGIPWCUuJolDQS/9zdFZDEXRhNsVeOHEKwFr+vpNU0himsHtLOhSEYlyPqwmeY8LUCKL6bLsDp0ScA==",
+      "version": "2.110.3",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.110.3.tgz",
+      "integrity": "sha512-YLxqxmz8Ug350yRh18ULsxj26xFu8LEx2YQ32RzwO2SLAZWCKwyxTiEXDl4ZjmDz7Fp23kjPCNzTfjHTcT5DWw==",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.1"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@supabase/realtime-js": {
-      "version": "2.109.0",
-      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.109.0.tgz",
-      "integrity": "sha512-q9tjGUgWLNhfLz6HeYE7yl6FG9WEsnr6bFmmLpn2Nakxp3Z36pqI4xu0xns5/n8Xtq10HVcy9CRxOxgvviCM4Q==",
+      "version": "2.110.3",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.110.3.tgz",
+      "integrity": "sha512-CVVoUWLqdQz4Uh/gg6mS9hmrnG2T/TIjgD8cCcn2W/MIFvypW5jXtUz8shEZToyHLpCWedKyeawVDgJF7JswVA==",
       "license": "MIT",
       "dependencies": {
         "@supabase/phoenix": "0.4.4",
         "tslib": "2.8.1"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@supabase/storage-js": {
-      "version": "2.109.0",
-      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.109.0.tgz",
-      "integrity": "sha512-j119SdEuwrOPGqiPjshpfovrQPFqeATKg990jNV88Ie+SEufznzVD2mL5kQvly+z2oVBeZn+pweU0QN/OYLmJw==",
+      "version": "2.110.3",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.110.3.tgz",
+      "integrity": "sha512-cslrXLgHGupTh6HTripRMxw70IDy0JD2hTiJg6oqP3hlQPBumLy8RoALycdBgocvq8ZhakYOZZWJZb1YPiEMtg==",
       "license": "MIT",
       "dependencies": {
         "iceberg-js": "^0.8.1",
         "tslib": "2.8.1"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@supabase/supabase-js": {
-      "version": "2.109.0",
-      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.109.0.tgz",
-      "integrity": "sha512-eNpUGegTT3hhoTK9j6aLViVjybYtdq6Ishb4BkVLi5tT58S1D80n7dmALMoBWkbrYG4uQv30c8iAB6nZylX0Fg==",
+      "version": "2.110.3",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.110.3.tgz",
+      "integrity": "sha512-Xg2dZas32iN0nvYjOEWjCP2oTSvQSnFqM6WJXhGI7Ue8HQ5IRuTmMZjThYxvqtAq1aUKBuiCxS9w0a8hJx4+lQ==",
       "license": "MIT",
       "dependencies": {
-        "@supabase/auth-js": "2.109.0",
-        "@supabase/functions-js": "2.109.0",
-        "@supabase/postgrest-js": "2.109.0",
-        "@supabase/realtime-js": "2.109.0",
-        "@supabase/storage-js": "2.109.0"
+        "@supabase/auth-js": "2.110.3",
+        "@supabase/functions-js": "2.110.3",
+        "@supabase/postgrest-js": "2.110.3",
+        "@supabase/realtime-js": "2.110.3",
+        "@supabase/storage-js": "2.110.3"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@tybys/wasm-util": {
@@ -17566,9 +17566,9 @@
       }
     },
     "node_modules/react-redux": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
-      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
+      "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
       "license": "MIT",
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",

--- a/Resonare/package.json
+++ b/Resonare/package.json
@@ -30,8 +30,8 @@
     "@react-navigation/bottom-tabs": "^7.18.8",
     "@react-navigation/native": "^7.3.8",
     "@react-navigation/stack": "^7.10.11",
-    "@reduxjs/toolkit": "^2.11.2",
-    "@supabase/supabase-js": "^2.109.0",
+    "@reduxjs/toolkit": "^2.12.0",
+    "@supabase/supabase-js": "^2.110.3",
     "@types/lodash": "^4.17.24",
     "@types/react-native-vector-icons": "^6.4.18",
     "bad-words": "^4.0.0",
@@ -55,7 +55,7 @@
     "react-native-view-shot": "^4.0.3",
     "react-native-webview": "^13.16.0",
     "react-native-worklets": "^0.7.1",
-    "react-redux": "^9.2.0"
+    "react-redux": "^9.3.0"
   },
   "devDependencies": {
     "@babel/core": "^7.29.7",


### PR DESCRIPTION
## Summary
Second round of safe updates Dependabot opened after the Phase 2 merges. Bundles the net-new npm bumps and the CI checkout bump into one self-verifying PR.

### npm (replaces net-new of [#145](https://github.com/jimmyshultz/musicboxd/pull/145))
[#145](https://github.com/jimmyshultz/musicboxd/pull/145) was cut before #153 merged, so most of it already landed. The genuinely-new bumps:
- `@reduxjs/toolkit` 2.11.2 → **2.12.0**
- `react-redux` 9.2.0 → **9.3.0**
- `@supabase/supabase-js` 2.109.0 → **2.110.3**

### CI (replaces [#140](https://github.com/jimmyshultz/musicboxd/pull/140))
- `actions/checkout` v6 → **v7** in both `lint` and `test` jobs. This PR's own CI run exercises checkout@v7.

`react-native-screens` held at 4.19.0; lockfile changes scoped to the bumped packages.

## Verification
Clean `npm ci` (mirrors CI):
- `npm run lint` ✅
- `npm test` ✅ (3 suites, 18 tests)
- `npm audit` → 0 vulnerabilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)