### PR TITLE
deps: TypeScript 5.9 → 6.0.3 (major, replaces #134)

### DIFF
--- a/Resonare/package-lock.json
+++ b/Resonare/package-lock.json
@@ -76,7 +76,7 @@
         "jest": "~30.3.0",
         "prettier": "^3.9.5",
         "react-test-renderer": "^19.2.7",
-        "typescript": "^5.9.3"
+        "typescript": "^6.0.3"
       },
       "engines": {
         "node": ">=18"
@@ -19129,9 +19129,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/Resonare/package.json
+++ b/Resonare/package.json
@@ -85,7 +85,7 @@
     "jest": "~30.3.0",
     "prettier": "^3.9.5",
     "react-test-renderer": "^19.2.7",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.3"
   },
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
## Summary
First Phase 3 major — the TypeScript compiler. Replaces Dependabot [#134](https://github.com/jimmyshultz/musicboxd/pull/134).

### Why 6.0.3 and not the latest 7.0.2
`@typescript-eslint@8.64` declares a TypeScript peer of **`>=4.8.4 <6.1.0`**. TS 7 (the native "Corsa" port) is out of that range and would risk breaking the `lint` gate (and needs a typescript-eslint that officially supports it, which isn't available yet). **TS 7 is a deliberate later step**; 6.0.3 is the safe major move now.

### Low blast radius
React Native transpiles via Babel/Metro, **not `tsc`** — so the compiler version affects only type-checking and eslint, never the app bundle.

## Verification
- `npm run lint` ✅ (0 errors; the 1 pre-existing "unused eslint-disable" *warning* is unchanged from `main`)
- `npm test` ✅ (3 suites, 18 tests)
- App `tsc --noEmit` error count **unchanged at 204** — TS 6.0.3 introduces no new type errors (these 204 are pre-existing debt, not CI-gated)
- `npm audit` → 0 vulnerabilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)