### PR TITLE
deps: async-storage 2.2.0 → 3.1.1 (native major)

### DIFF
--- a/Resonare/ios/Podfile.lock
+++ b/Resonare/ios/Podfile.lock
@@ -9,6 +9,34 @@ PODS:
     - GoogleUtilities/Environment (~> 8.0)
     - GoogleUtilities/UserDefaults (~> 8.0)
     - PromisesObjC (~> 2.4)
+  - AsyncStorage (3.1.1):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-jsi
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-renderercss
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+    - Yoga
   - boost (1.84.0)
   - DoubleConversion (1.1.6)
   - fast_float (8.0.0)
@@ -2819,34 +2847,6 @@ PODS:
     - SocketRocket
   - RNAppleAuthentication (2.5.1):
     - React-Core
-  - RNCAsyncStorage (2.2.0):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-ImageManager
-    - React-jsi
-    - React-NativeModulesApple
-    - React-RCTFabric
-    - React-renderercss
-    - React-rendererdebug
-    - React-utils
-    - ReactCodegen
-    - ReactCommon/turbomodule/bridging
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-    - Yoga
   - RNDateTimePicker (8.6.0):
     - boost
     - DoubleConversion
@@ -3488,6 +3488,7 @@ PODS:
   - Yoga (0.0.0)
 
 DEPENDENCIES:
+  - "AsyncStorage (from `../node_modules/@react-native-async-storage/async-storage`)"
   - boost (from `../node_modules/react-native/third-party-podspecs/boost.podspec`)
   - DoubleConversion (from `../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec`)
   - fast_float (from `../node_modules/react-native/third-party-podspecs/fast_float.podspec`)
@@ -3582,7 +3583,6 @@ DEPENDENCIES:
   - ReactCodegen (from `build/generated/ios/ReactCodegen`)
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
   - "RNAppleAuthentication (from `../node_modules/@invertase/react-native-apple-authentication`)"
-  - "RNCAsyncStorage (from `../node_modules/@react-native-async-storage/async-storage`)"
   - "RNDateTimePicker (from `../node_modules/@react-native-community/datetimepicker`)"
   - "RNFastImage (from `../node_modules/@d11/react-native-fast-image`)"
   - "RNFBApp (from `../node_modules/@react-native-firebase/app`)"
@@ -3635,6 +3635,8 @@ SPEC REPOS:
     - TOCropViewController
 
 EXTERNAL SOURCES:
+  AsyncStorage:
+    :path: "../node_modules/@react-native-async-storage/async-storage"
   boost:
     :podspec: "../node_modules/react-native/third-party-podspecs/boost.podspec"
   DoubleConversion:
@@ -3802,8 +3804,6 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon"
   RNAppleAuthentication:
     :path: "../node_modules/@invertase/react-native-apple-authentication"
-  RNCAsyncStorage:
-    :path: "../node_modules/@react-native-async-storage/async-storage"
   RNDateTimePicker:
     :path: "../node_modules/@react-native-community/datetimepicker"
   RNFastImage:
@@ -3840,6 +3840,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   AppAuth: 1c1a8afa7e12f2ec3a294d9882dfa5ab7d3cb063
   AppCheckCore: cc8fd0a3a230ddd401f326489c99990b013f0c4f
+  AsyncStorage: 10b4956c3184302f5003b3360acc30b9c59dce1e
   boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
   DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
   fast_float: b32c788ed9c6a8c584d114d0047beda9664e7cc6
@@ -3945,7 +3946,6 @@ SPEC CHECKSUMS:
   ReactCodegen: 3d48510bcef445f6403c0004047d4d9cbb915435
   ReactCommon: ac934cb340aee91282ecd6f273a26d24d4c55cae
   RNAppleAuthentication: a89c9804592b38ed4ab11f0aee68d05ba12ad432
-  RNCAsyncStorage: 29f0230e1a25f36c20b05f65e2eb8958d6526e82
   RNDateTimePicker: 97a86d7c8b51f2d51f694a9dddfe5996dfd9a407
   RNFastImage: b076a6378b1ce90debc27a927a437db3652bef14
   RNFBApp: b094e527070715680bf25d019ac853d1f22d92df

--- a/Resonare/ios/Resonare/PrivacyInfo.xcprivacy
+++ b/Resonare/ios/Resonare/PrivacyInfo.xcprivacy
@@ -6,6 +6,15 @@
 	<array>
 		<dict>
 			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>C617.1</string>
+				<string>3B52.1</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
 			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
 			<key>NSPrivacyAccessedAPITypeReasons</key>
 			<array>
@@ -28,15 +37,6 @@
 			<key>NSPrivacyAccessedAPITypeReasons</key>
 			<array>
 				<string>E174.1</string>
-			</array>
-		</dict>
-		<dict>
-			<key>NSPrivacyAccessedAPIType</key>
-			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
-			<key>NSPrivacyAccessedAPITypeReasons</key>
-			<array>
-				<string>C617.1</string>
-				<string>3B52.1</string>
 			</array>
 		</dict>
 	</array>

--- a/Resonare/jest.config.js
+++ b/Resonare/jest.config.js
@@ -3,6 +3,7 @@ module.exports = {
   transformIgnorePatterns: [
     'node_modules/(?!(react-native' +
       '|@react-native' +
+      '|@react-native-async-storage/async-storage' +
       '|react-native-paper' +
       '|react-native-gesture-handler' +
       '|react-native-reanimated' +

--- a/Resonare/jest.setup.js
+++ b/Resonare/jest.setup.js
@@ -18,7 +18,7 @@ if (typeof global.WebSocket === 'undefined') {
 jest.mock('react-native/Libraries/EventEmitter/NativeEventEmitter');
 
 jest.mock('@react-native-async-storage/async-storage', () =>
-  require('@react-native-async-storage/async-storage/jest/async-storage-mock'),
+  require('@react-native-async-storage/async-storage/jest'),
 );
 
 // Firebase native modules are unavailable under Jest; mock the modular API

--- a/Resonare/package-lock.json
+++ b/Resonare/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@d11/react-native-fast-image": "^8.13.0",
         "@invertase/react-native-apple-authentication": "^2.5.1",
-        "@react-native-async-storage/async-storage": "^2.2.0",
+        "@react-native-async-storage/async-storage": "^3.1.1",
         "@react-native-camera-roll/camera-roll": "^7.10.2",
         "@react-native-community/datetimepicker": "^8.6.0",
         "@react-native-firebase/app": "^23.8.3",
@@ -2609,7 +2609,26 @@
       "integrity": "sha512-kRVpIl4vVGJ4baogMDINbyrIOtOxqhkZQg4jTq3l8Lw6WSk0xfpEYzezFu+Kl4ve4fbPl79dvwRtaFqAC/ucCw==",
       "license": "Apache-2.0"
     },
-    "node_modules/@firebase/auth": {
+    "node_modules/@firebase/auth-compat": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-compat/-/auth-compat-0.6.2.tgz",
+      "integrity": "sha512-8UhCzF6pav9bw/eXA8Zy1QAKssPRYEYXaWagie1ewLTwHkXv6bKp/j6/IwzSYQP67sy/BMFXIFaCCsoXzFLr7A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/auth": "1.12.0",
+        "@firebase/auth-types": "0.13.0",
+        "@firebase/component": "0.7.0",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/auth-compat/node_modules/@firebase/auth": {
       "version": "1.12.0",
       "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-1.12.0.tgz",
       "integrity": "sha512-zkvLpsrxynWHk07qGrUDfCSqKf4AvfZGEqJ7mVCtYGjNNDbGE71k0Yn84rg8QEZu4hQw1BC0qDEHzpNVBcSVmA==",
@@ -2633,23 +2652,18 @@
         }
       }
     },
-    "node_modules/@firebase/auth-compat": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/@firebase/auth-compat/-/auth-compat-0.6.2.tgz",
-      "integrity": "sha512-8UhCzF6pav9bw/eXA8Zy1QAKssPRYEYXaWagie1ewLTwHkXv6bKp/j6/IwzSYQP67sy/BMFXIFaCCsoXzFLr7A==",
-      "license": "Apache-2.0",
+    "node_modules/@firebase/auth-compat/node_modules/@react-native-async-storage/async-storage": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-2.2.0.tgz",
+      "integrity": "sha512-gvRvjR5JAaUZF8tv2Kcq/Gbt3JHwbKFYfmb445rhOj6NUMx3qPLixmDx5pZAyb9at1bYvJ4/eTUipU5aki45xw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
-        "@firebase/auth": "1.12.0",
-        "@firebase/auth-types": "0.13.0",
-        "@firebase/component": "0.7.0",
-        "@firebase/util": "1.13.0",
-        "tslib": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=20.0.0"
+        "merge-options": "^3.0.4"
       },
       "peerDependencies": {
-        "@firebase/app-compat": "0.x"
+        "react-native": "^0.0.0-0 || >=0.65 <1.0"
       }
     },
     "node_modules/@firebase/auth-interop-types": {
@@ -5566,16 +5580,23 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@react-native-async-storage/async-storage": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-2.2.0.tgz",
-      "integrity": "sha512-gvRvjR5JAaUZF8tv2Kcq/Gbt3JHwbKFYfmb445rhOj6NUMx3qPLixmDx5pZAyb9at1bYvJ4/eTUipU5aki45xw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-3.1.1.tgz",
+      "integrity": "sha512-z+PnLz1n6ECKhgoHZHkfc+dijXZEyZnNFSajbtE0NEbsJhmX8x9GlOeiMQIKX2E4DUqPSgfIh4FYBv1M49KgPQ==",
       "license": "MIT",
       "dependencies": {
-        "merge-options": "^3.0.4"
+        "idb": "8.0.3"
       },
       "peerDependencies": {
-        "react-native": "^0.0.0-0 || >=0.65 <1.0"
+        "react": "*",
+        "react-native": "*"
       }
+    },
+    "node_modules/@react-native-async-storage/async-storage/node_modules/idb": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-8.0.3.tgz",
+      "integrity": "sha512-LtwtVyVYO5BqRvcsKuB2iUMnHwPVByPCXFXOpuU96IZPPoPN6xjOGxZQ74pgSVVLQWtUOYgyeL4GE98BY5D3wg==",
+      "license": "ISC"
     },
     "node_modules/@react-native-camera-roll/camera-roll": {
       "version": "7.10.2",
@@ -10288,6 +10309,44 @@
         "@firebase/util": "1.13.0"
       }
     },
+    "node_modules/firebase/node_modules/@firebase/auth": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-1.12.0.tgz",
+      "integrity": "sha512-zkvLpsrxynWHk07qGrUDfCSqKf4AvfZGEqJ7mVCtYGjNNDbGE71k0Yn84rg8QEZu4hQw1BC0qDEHzpNVBcSVmA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.0",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x",
+        "@react-native-async-storage/async-storage": "^2.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@react-native-async-storage/async-storage": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/firebase/node_modules/@react-native-async-storage/async-storage": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-2.2.0.tgz",
+      "integrity": "sha512-gvRvjR5JAaUZF8tv2Kcq/Gbt3JHwbKFYfmb445rhOj6NUMx3qPLixmDx5pZAyb9at1bYvJ4/eTUipU5aki45xw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "merge-options": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react-native": "^0.0.0-0 || >=0.65 <1.0"
+      }
+    },
     "node_modules/flat-cache": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
@@ -11374,6 +11433,8 @@
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
       "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -15731,6 +15792,8 @@
       "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
       "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "is-plain-obj": "^2.1.0"
       },

--- a/Resonare/package.json
+++ b/Resonare/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@d11/react-native-fast-image": "^8.13.0",
     "@invertase/react-native-apple-authentication": "^2.5.1",
-    "@react-native-async-storage/async-storage": "^2.2.0",
+    "@react-native-async-storage/async-storage": "^3.1.1",
     "@react-native-camera-roll/camera-roll": "^7.10.2",
     "@react-native-community/datetimepicker": "^8.6.0",
     "@react-native-firebase/app": "^23.8.3",


### PR DESCRIPTION
Native major upgrade of `@react-native-async-storage/async-storage` (2.2.0 → 3.1.1), replacing stale Dependabot PR #151. First upgrade in the native/RN phase, verified on the iOS simulator.

## App code
No migration needed. The only usage is as the Supabase auth `storage` adapter (`src/services/supabase.ts:46`). 3.x's default export keeps the same `getItem`/`setItem`/`removeItem` surface the adapter requires. The 3.0 API changes that *don't* affect us: `multiGet`/`multiSet` → `getMany`/`setMany`, removed `useAsyncStorage` hook, removed callback API (grep confirms zero usage of any).

## Jest (only source change) — CI gate caught this
1. 3.x renamed the mock subpath `jest/async-storage-mock` → `jest` (its default export is a working in-memory storage instance).
2. 3.x ships **ESM-only** (`lib/module`, no `lib/commonjs`), so async-storage must be Babel-transformed under Jest — added it to the `transformIgnorePatterns` allowlist. Without this, `App.test.tsx` fails to run on `export` syntax.

Result: **18/18 tests, 3 suites**; lint clean.

## Native (iOS)
`pod install` swaps `RNCAsyncStorage 2.2.0` → `AsyncStorage 3.1.1` and regenerates the New Architecture codegen spec (`AsyncStorageSpec`). `PrivacyInfo.xcprivacy` is a pure reorder from regeneration — no declarations added/removed.

## Verification (iPhone 17 Pro sim, dev env)
- Clean build + launch ✅
- **Session persists across a full cold restart** (terminate + relaunch → still logged in, feed intact) — proves read/write against the real native module ✅
- Interactive logout → login works ✅
- lint clean, 18/18 tests ✅

### Note
On the *first* launch after install, one transient `AsyncStorageError: Native module is null` fired during Supabase's auto-refresh tick (TurboModule registration race at startup). Supabase labels it transient and retries; it did **not** recur on cold restart. Benign.

Closes #151.

🤖 Generated with [Claude Code](https://claude.com/claude-code)