### PR TITLE
deps: react-native-gesture-handler 2.30.0 → 3.0.2 (native major)

### DIFF
--- a/Resonare/ios/Podfile.lock
+++ b/Resonare/ios/Podfile.lock
@@ -3000,7 +3000,7 @@ PODS:
     - RNFBApp
     - SocketRocket
     - Yoga
-  - RNGestureHandler (2.30.0):
+  - RNGestureHandler (3.0.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -3951,7 +3951,7 @@ SPEC CHECKSUMS:
   RNFBApp: b094e527070715680bf25d019ac853d1f22d92df
   RNFBCrashlytics: 9855f0e35a60e5c062132a59b790275f54ce5008
   RNFBMessaging: 853b4e8f0a07240e25fea4acc53b600967925b8a
-  RNGestureHandler: cd4be101cfa17ea6bbd438710caa02e286a84381
+  RNGestureHandler: 70d7c8cd6de51cff63c68789b04a1e03f1b9eef3
   RNGoogleMobileAds: 4f4de7299a78165a20bc352e6360a4e9619147ad
   RNGoogleSignin: 4122717989e2544988cb4cec3e917da3ebc969a5
   RNImageCropPicker: 5fd4ceaead64d8c53c787e4e559004f97bc76df7

--- a/Resonare/jest.config.js
+++ b/Resonare/jest.config.js
@@ -7,6 +7,7 @@ module.exports = {
       '|react-native-paper' +
       '|react-native-gesture-handler' +
       '|react-native-reanimated' +
+      '|react-native-worklets' +
       '|react-native-screens' +
       '|react-native-safe-area-context' +
       '|@react-navigation' +

--- a/Resonare/jest.setup.js
+++ b/Resonare/jest.setup.js
@@ -51,6 +51,13 @@ jest.mock('@react-native-firebase/crashlytics', () => ({
   crash: jest.fn(),
 }));
 
+// reanimated 4's mock loads reanimated's real index, which imports
+// react-native-worklets and hits its native module (absent under Jest).
+// Mock worklets with its own Jest mock so the native init never runs.
+jest.mock('react-native-worklets', () =>
+  require('react-native-worklets/lib/module/mock'),
+);
+
 jest.mock('react-native-reanimated', () =>
   require('react-native-reanimated/mock'),
 );

--- a/Resonare/package-lock.json
+++ b/Resonare/package-lock.json
@@ -31,7 +31,7 @@
         "react": "^19.2.7",
         "react-native": "^0.83.1",
         "react-native-config": "^1.6.1",
-        "react-native-gesture-handler": "^2.30.0",
+        "react-native-gesture-handler": "^3.0.2",
         "react-native-google-mobile-ads": "^16.0.1",
         "react-native-image-crop-picker": "^0.51.1",
         "react-native-image-picker": "^8.2.1",
@@ -2213,18 +2213,6 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
-      }
-    },
-    "node_modules/@egjs/hammerjs": {
-      "version": "2.0.17",
-      "resolved": "https://registry.npmjs.org/@egjs/hammerjs/-/hammerjs-2.0.17.tgz",
-      "integrity": "sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hammerjs": "^2.0.36"
-      },
-      "engines": {
-        "node": ">=0.8.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -6695,12 +6683,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/hammerjs": {
-      "version": "2.0.46",
-      "resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.46.tgz",
-      "integrity": "sha512-ynRvcq6wvqexJ9brDMS4BnBLzmr0e14d6ZJTEShTBWKymQiHwlAyGu0ZPEFI2Fh1U53F7tN9ufClWM5KvqkKOw==",
-      "license": "MIT"
-    },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
@@ -6845,7 +6827,6 @@
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/@types/react-test-renderer/-/react-test-renderer-19.1.0.tgz",
       "integrity": "sha512-XD0WZrHqjNrxA/MaR9O22w/RNidWR9YZmBdRGI7wcnWGrv/3dA8wKCJ8m63Sn+tLJhcjmuhOi629N66W6kgWzQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/react": "*"
@@ -17260,13 +17241,12 @@
       }
     },
     "node_modules/react-native-gesture-handler": {
-      "version": "2.30.0",
-      "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.30.0.tgz",
-      "integrity": "sha512-5YsnKHGa0X9C8lb5oCnKm0fLUPM6CRduvUUw2Bav4RIj/C3HcFh4RIUnF8wgG6JQWCL1//gRx4v+LVWgcIQdGA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-3.0.2.tgz",
+      "integrity": "sha512-XBTgmvr2jh/xrMwlHTV2Z1x6IFUl3zfLxyaCAnvj3GSXK5YlY3ZmiIs57hniPmh3I7RtjPFxtGdRr0i+PzyBrg==",
       "license": "MIT",
       "dependencies": {
-        "@egjs/hammerjs": "^2.0.17",
-        "hoist-non-react-statics": "^3.3.0",
+        "@types/react-test-renderer": "^19.1.0",
         "invariant": "^2.2.4"
       },
       "peerDependencies": {

--- a/Resonare/package.json
+++ b/Resonare/package.json
@@ -40,7 +40,7 @@
     "react": "^19.2.7",
     "react-native": "^0.83.1",
     "react-native-config": "^1.6.1",
-    "react-native-gesture-handler": "^2.30.0",
+    "react-native-gesture-handler": "^3.0.2",
     "react-native-google-mobile-ads": "^16.0.1",
     "react-native-image-crop-picker": "^0.51.1",
     "react-native-image-picker": "^8.2.1",

--- a/Resonare/src/screens/Profile/NotificationsScreen.tsx
+++ b/Resonare/src/screens/Profile/NotificationsScreen.tsx
@@ -5,7 +5,6 @@ import {
   StyleSheet,
   RefreshControl,
   TouchableOpacity,
-  Animated,
   Alert,
 } from 'react-native';
 import {
@@ -15,7 +14,15 @@ import {
   useTheme,
   Button,
 } from 'react-native-paper';
-import { Swipeable } from 'react-native-gesture-handler';
+import ReanimatedSwipeable, {
+  SwipeableMethods,
+} from 'react-native-gesture-handler/ReanimatedSwipeable';
+import Reanimated, {
+  interpolate,
+  Extrapolation,
+  useAnimatedStyle,
+  SharedValue,
+} from 'react-native-reanimated';
 import { useNavigation } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
 import { useDispatch, useSelector } from 'react-redux';
@@ -46,6 +53,40 @@ type NotificationsScreenNavigationProp = StackNavigationProp<
   'Notifications'
 >;
 
+// Right swipe action. Extracted into its own component so the reanimated
+// `useAnimatedStyle` hook isn't called inside ReanimatedSwipeable's
+// renderRightActions render callback (rules of hooks).
+const RightAction: React.FC<{
+  translation: SharedValue<number>;
+  onDelete: () => void;
+  styles: any;
+}> = ({ translation, onDelete, styles }) => {
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [
+      {
+        scale: interpolate(
+          translation.value,
+          [-100, 0],
+          [1, 0],
+          Extrapolation.CLAMP,
+        ),
+      },
+    ],
+  }));
+
+  return (
+    <TouchableOpacity
+      style={styles.deleteAction}
+      onPress={onDelete}
+      activeOpacity={0.7}
+    >
+      <Reanimated.View style={[styles.deleteActionContent, animatedStyle]}>
+        <Icon name="trash" size={24} color="#fff" />
+      </Reanimated.View>
+    </TouchableOpacity>
+  );
+};
+
 // Separate component for notification item to allow hooks
 interface NotificationItemProps {
   item: AppNotification;
@@ -66,36 +107,22 @@ const NotificationItem: React.FC<NotificationItemProps> = ({
   theme: _theme,
   styles,
 }) => {
-  const swipeableRef = useRef<Swipeable>(null);
+  const swipeableRef = useRef<SwipeableMethods>(null);
   const isUnread = !item.read;
 
   const renderRightActions = (
-    progress: Animated.AnimatedInterpolation<number>,
-    dragX: Animated.AnimatedInterpolation<number>,
-  ) => {
-    const scale = dragX.interpolate({
-      inputRange: [-100, 0],
-      outputRange: [1, 0],
-      extrapolate: 'clamp',
-    });
-
-    return (
-      <TouchableOpacity
-        style={styles.deleteAction}
-        onPress={() => onDelete(item.id)}
-        activeOpacity={0.7}
-      >
-        <Animated.View
-          style={[styles.deleteActionContent, { transform: [{ scale }] }]}
-        >
-          <Icon name="trash" size={24} color="#fff" />
-        </Animated.View>
-      </TouchableOpacity>
-    );
-  };
+    _progress: SharedValue<number>,
+    translation: SharedValue<number>,
+  ) => (
+    <RightAction
+      translation={translation}
+      onDelete={() => onDelete(item.id)}
+      styles={styles}
+    />
+  );
 
   return (
-    <Swipeable
+    <ReanimatedSwipeable
       ref={swipeableRef}
       renderRightActions={renderRightActions}
       rightThreshold={40}
@@ -128,7 +155,7 @@ const NotificationItem: React.FC<NotificationItemProps> = ({
           </Card.Content>
         </Card>
       </TouchableOpacity>
-    </Swipeable>
+    </ReanimatedSwipeable>
   );
 };
 


### PR DESCRIPTION
Native major upgrade of `react-native-gesture-handler` (2.30.0 → 3.0.2), replacing stale Dependabot PR #152. Verified on the iOS simulator.

## Breaking change + app migration
gesture-handler 3 **removed the legacy `Swipeable`** (and `DrawerLayout`) from the root export; the replacement is the reanimated-based default export at `react-native-gesture-handler/ReanimatedSwipeable`. The app used `Swipeable` in exactly one place — `src/screens/Profile/NotificationsScreen.tsx` (notifications swipe-to-delete).

Migration:
- Import default `ReanimatedSwipeable`; ref type `Swipeable` → `SwipeableMethods`.
- `renderRightActions` now receives reanimated `SharedValue<number>` args (`progress`, `translation`) instead of RN `Animated.AnimatedInterpolation` (`progress`, `dragX`). The trash-icon scale animation is rewritten with reanimated `useAnimatedStyle`/`interpolate`/`Extrapolation`, extracted into a `RightAction` component (hooks can't run inside the render-prop callback).
- `tsc`: no new type errors in the migrated file.

## Jest — CI gate caught this
Rendering `<App/>` loads the nav tree → the reanimated mock → the **real** `react-native-worklets`, which hits its native module (absent under Jest). Fixed by:
1. Adding `react-native-worklets` to `transformIgnorePatterns` (it's ESM).
2. `jest.mock('react-native-worklets', () => require('react-native-worklets/lib/module/mock'))` — worklets' own Jest mock, so native init never runs.

Result: **18/18 tests, 3 suites**; lint clean.

## Native (iOS)
`pod install` → `RNGestureHandler 3.0.2` and regenerated the New Architecture codegen for gesture-handler/reanimated/worklets. 130 pods.

## Verification (iPhone 17 Pro sim, dev env)
- Clean build + launch, feed renders ✅
- No gesture/reanimated/worklets runtime errors in the device log ✅
- **Interactive swipe-to-delete works** — the migrated reanimated scale animation on the trash icon behaves correctly, delete removes the row ✅
- lint clean, 18/18 tests ✅

Closes #152.

🤖 Generated with [Claude Code](https://claude.com/claude-code)