### PR TITLE
chore: correct Dependabot holds after the RN 0.86 upgrade

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -81,15 +81,31 @@ updates:
       # React Native major versions need careful migration
       - dependency-name: "react-native"
         update-types: ["version-update:semver-major"]
-      # jest 30.4+ calls jest-mock APIs (clearMocksOnScope) that RN 0.83's
-      # bundled jest-environment-node@29 preset doesn't provide. Hold jest at
-      # 30.3.x until react-native is upgraded (jest-environment moves to 30).
+      # jest 30.4+ calls a jest-mock API (clearMocksOnScope) that jest-mock@29
+      # doesn't provide. @react-native/jest-preset (still 0.86) depends on
+      # jest-environment-node@^29.7.0, which hoists jest-mock@29.7.0, so all
+      # suites fail with "clearMocksOnScope is not a function". Re-verified on
+      # RN 0.86 — still broken. Revisit when @react-native/jest-preset moves to
+      # the jest 30 environment packages.
       - dependency-name: "jest"
         versions: [">=30.4.0"]
-      # react-native-screens 4.26+ requires react-native >=0.84 (peer); the app
-      # is on RN 0.83. Hold at 4.19–4.25 until react-native is upgraded.
-      - dependency-name: "react-native-screens"
-        versions: [">=4.26.0"]
+      # eslint 10 is not supported by the plugin set that
+      # @react-native/eslint-config@0.86 pins: the config itself declares
+      # peer eslint "^8.0.0 || ^9.0.0", and @babel/eslint-parser,
+      # eslint-plugin-ft-flow, eslint-plugin-react and
+      # eslint-plugin-react-native all cap at eslint 9 even at latest.
+      # Revisit when @react-native/eslint-config supports eslint 10.
+      - dependency-name: "eslint"
+        versions: [">=10.0.0"]
+      # Babel 8 can't be adopted piecemeal: @react-native/babel-preset@0.86 is
+      # still entirely Babel 7 (@babel/core ^7.25.2 plus ~29 @babel/* 7.x
+      # plugins). Taking @babel/core or @babel/runtime to 8 would create a
+      # split-brain toolchain. Revisit when @react-native/babel-preset is
+      # Babel 8 capable.
+      - dependency-name: "@babel/core"
+        versions: [">=8.0.0"]
+      - dependency-name: "@babel/runtime"
+        versions: [">=8.0.0"]
     commit-message:
       prefix: "deps"
       include: "scope"


### PR DESCRIPTION
The RN 0.86 upgrade was expected to unblock ESLint 10, Babel 8, jest 30.4 and react-native-screens 4.26. I re-verified each against RN 0.86 instead of assuming — **only one of the four is actually unblocked.**

## Findings

| Hold | Expected | Actual | Action |
|---|---|---|---|
| `react-native-screens` >=4.26 | unblocked | ✅ unblocked — peer `react-native` is now `*` | **hold dropped** |
| `jest` >=30.4 | unblocked | ❌ still fails (re-tested) | hold kept, reason corrected |
| `eslint` >=10 | unblocked | ❌ still blocked | **hold added** |
| `@babel/core` / `@babel/runtime` >=8 | unblocked | ❌ still blocked | **hold added** |

### jest 30.4 — re-tested, still broken
`@react-native/jest-preset@0.86` depends on `jest-environment-node@^29.7.0`, which hoists `jest-mock@29.7.0`. jest 30.4's `clearMocksOnScope` call then fails. Installing jest 30.4.2 on RN 0.86 gives **3 failed suites, 0 tests run**:
```
TypeError: this._moduleMocker.clearMocksOnScope is not a function
```
The original hold blamed RN 0.83; the real constraint is the jest-preset package, so the comment is updated.

### ESLint 10 — still blocked
`@react-native/eslint-config@0.86.0` itself declares `peer eslint "^8.0.0 || ^9.0.0"`. Its plugin set caps at eslint 9 even at latest: `eslint-plugin-react` (`…|| ^9.7`), `eslint-plugin-react-native` (`…|| ^9`), `eslint-plugin-ft-flow` (`^8.56.0 || ^9.0.0`), `@babel/eslint-parser` (`…|| ^9.0.0`).

### Babel 8 — still blocked
`@react-native/babel-preset@0.86` is still entirely Babel 7 — `@babel/core ^7.25.2` plus ~29 `@babel/*` 7.x plugins. Moving `@babel/core` or `@babel/runtime` to 8 would produce a split-brain toolchain (transforms on 7, runtime helpers on 8) that jest wouldn't catch but Metro could break on.

## Effect
Dependabot stops re-proposing the three unmergeable upgrades, and is free to propose `react-native-screens` 4.26+ (picked up in the RN group refresh).

Closes #161, #162, #150.

🤖 Generated with [Claude Code](https://claude.com/claude-code)