### PR TITLE
chore: hold @eslint/js 10 and @babel/preset-env 8

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -95,16 +95,29 @@ updates:
       # eslint-plugin-ft-flow, eslint-plugin-react and
       # eslint-plugin-react-native all cap at eslint 9 even at latest.
       # Revisit when @react-native/eslint-config supports eslint 10.
+      #
+      # NOTE: these ignores match on package NAME, so holding "eslint" alone
+      # does not hold the rest of the family — @eslint/js@10 declares
+      # peer eslint "^10.0.0" and was proposed separately (#180). Every
+      # package in a held toolchain family needs its own entry.
       - dependency-name: "eslint"
+        versions: [">=10.0.0"]
+      - dependency-name: "@eslint/js"
         versions: [">=10.0.0"]
       # Babel 8 can't be adopted piecemeal: @react-native/babel-preset@0.86 is
       # still entirely Babel 7 (@babel/core ^7.25.2 plus ~29 @babel/* 7.x
       # plugins). Taking @babel/core or @babel/runtime to 8 would create a
       # split-brain toolchain. Revisit when @react-native/babel-preset is
       # Babel 8 capable.
+      #
+      # Same name-matching caveat as eslint above: @babel/preset-env@8
+      # declares peer @babel/core "^8.0.0" and was proposed separately (#176)
+      # despite @babel/core itself being held.
       - dependency-name: "@babel/core"
         versions: [">=8.0.0"]
       - dependency-name: "@babel/runtime"
+        versions: [">=8.0.0"]
+      - dependency-name: "@babel/preset-env"
         versions: [">=8.0.0"]
     commit-message:
       prefix: "deps"


### PR DESCRIPTION
Dependabot `ignore` entries match on package **name**, so the ESLint 10 and Babel 8 holds added in #174 only covered the packages actually named in them. Both blocked majors were re-proposed within hours under sibling names:

| PR | Bump | Peer requirement | CI |
|---|---|---|---|
| #180 | `@eslint/js` 9.39.2 → 10.0.1 | `eslint ^10.0.0` | lint + test **fail** |
| #176 | `@babel/preset-env` 7.29.7 → 8.0.2 | `@babel/core ^8.0.0` | lint + test **fail** |

Neither is mergeable, for exactly the reasons #174 documented:

- **ESLint 10** — `@react-native/eslint-config@0.86.2` itself declares peer `eslint "^8.0.0 || ^9.0.0"`, and `eslint-plugin-react` (`^9.7`), `eslint-plugin-react-native` (`^9`), `eslint-plugin-ft-flow` (`^9`) and `@babel/eslint-parser` all cap at eslint 9 even at latest.
- **Babel 8** — `@react-native/babel-preset@0.86` is still entirely Babel 7 (`@babel/core ^7.25.2` plus ~29 `@babel/*` 7.x plugins). Moving `preset-env` to 8 alone is the same split-brain toolchain #174 rejected.

This adds an ignore for each, plus a comment on the name-matching behaviour so the next person holding a toolchain major knows to cover the whole family rather than just the headline package.

## Family coverage

Checked the manifest rather than only patching the two that surfaced:

- **Babel** — the family here is exactly `@babel/core` + `@babel/preset-env` + `@babel/runtime`. All three now held. Complete.
- **ESLint** — `eslint` and `@eslint/js` held. `@eslint/eslintrc` is still on 3.x with no v4 published, so there is no version to hold yet. The `eslint-plugin-*` packages cap themselves at eslint 9, so they can't jump ahead on their own.

## Effect

Dependabot stops re-proposing the two unmergeable upgrades. Nothing else changes — no dependency versions move in this PR.

Closes #176, #180.

🤖 Generated with [Claude Code](https://claude.com/claude-code)