### PR TITLE
deps: react-native-url-polyfill 3.0.0 → 4.0.0

### DIFF
--- a/Resonare/package-lock.json
+++ b/Resonare/package-lock.json
@@ -41,7 +41,7 @@
         "react-native-safe-area-context": "^5.8.0",
         "react-native-screens": "^4.26.2",
         "react-native-share": "^12.3.1",
-        "react-native-url-polyfill": "^3.0.0",
+        "react-native-url-polyfill": "^4.0.0",
         "react-native-vector-icons": "^10.3.0",
         "react-native-view-shot": "^5.1.1",
         "react-native-webview": "^15.0.0",
@@ -16883,6 +16883,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -17331,13 +17332,10 @@
       }
     },
     "node_modules/react-native-url-polyfill": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/react-native-url-polyfill/-/react-native-url-polyfill-3.0.0.tgz",
-      "integrity": "sha512-aA5CiuUCUb/lbrliVCJ6lZ17/RpNJzvTO/C7gC/YmDQhTUoRD5q5HlJfwLWcxz4VgAhHwXKzhxH+wUN24tAdqg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/react-native-url-polyfill/-/react-native-url-polyfill-4.0.0.tgz",
+      "integrity": "sha512-eqYM3wBAA0eL1sPYbBAoNfbES3+NkgcxUdelQ7QzmoVtqKB5qGG0U13MPTRUroAWK+y2EoJFS3MZUK0fwTf0pA==",
       "license": "MIT",
-      "dependencies": {
-        "whatwg-url-without-unicode": "8.0.0-3"
-      },
       "peerDependencies": {
         "react-native": "*"
       }
@@ -19362,15 +19360,6 @@
       "integrity": "sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==",
       "license": "Apache-2.0"
     },
-    "node_modules/webidl-conversions": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
-      "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/websocket-driver": {
       "version": "0.7.5",
       "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.5.tgz",
@@ -19399,44 +19388,6 @@
       "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
       "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==",
       "license": "MIT"
-    },
-    "node_modules/whatwg-url-without-unicode": {
-      "version": "8.0.0-3",
-      "resolved": "https://registry.npmjs.org/whatwg-url-without-unicode/-/whatwg-url-without-unicode-8.0.0-3.tgz",
-      "integrity": "sha512-HoKuzZrUlgpz35YO27XgD28uh/WJH4B0+3ttFqRo//lmq+9T/mIOJ6kqmINI9HpUpz1imRC/nR/lxKpJiv0uig==",
-      "license": "MIT",
-      "dependencies": {
-        "buffer": "^5.4.3",
-        "punycode": "^2.1.1",
-        "webidl-conversions": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/whatwg-url-without-unicode/node_modules/buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
-      }
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/Resonare/package.json
+++ b/Resonare/package.json
@@ -50,7 +50,7 @@
     "react-native-safe-area-context": "^5.8.0",
     "react-native-screens": "^4.26.2",
     "react-native-share": "^12.3.1",
-    "react-native-url-polyfill": "^3.0.0",
+    "react-native-url-polyfill": "^4.0.0",
     "react-native-vector-icons": "^10.3.0",
     "react-native-view-shot": "^5.1.1",
     "react-native-webview": "^15.0.0",


### PR DESCRIPTION
Replaces #185 (rebased onto current main, and verified at runtime — which the Dependabot PR can't be).

## What changed in v4

It's an internal rewrite. v4 drops `whatwg-url-without-unicode` (v3's only dependency) and ships its own dependency-free WHATWG-spec implementation of `URL` and `URLSearchParams`, adding `URL.parse` / `URL.canParse` statics and blob-URL support via `NativeModules.BlobModule`.

The public surface is unchanged — same `react-native-url-polyfill/auto` side-effect import installing the same globals. **But the parsing engine underneath is entirely new**, and this app routes all Supabase traffic through it ([supabase.ts:1](Resonare/src/services/supabase.ts:1) is the only importer). So the risk here is runtime behaviour, not types — which means lint and Jest alone aren't a meaningful gate.

Pure JS: no podspec, so no `pod install` and no native rebuild.

## Verification

- `npm run lint` — 0 errors
- `npm test` — 18/18
- On the iPhone 17 Pro simulator with a fresh Metro cache:
  - session restores from AsyncStorage (auth token refresh URL builds correctly)
  - home feed renders, AdMob banner intact
  - **Profile loads live Supabase data** — REST query, plus storage image URLs resolving

That last one is the real check: it exercises URL construction across REST, auth, and storage under the new parser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)