### PR TITLE
deps: remove unused react-native-webview

### DIFF
--- a/Resonare/ios/Podfile.lock
+++ b/Resonare/ios/Podfile.lock
@@ -1746,28 +1746,6 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - react-native-webview (15.0.0):
-    - hermes-engine
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-Core-prebuilt
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-ImageManager
-    - React-jsi
-    - React-NativeModulesApple
-    - React-RCTFabric
-    - React-renderercss
-    - React-rendererdebug
-    - React-utils
-    - ReactCodegen
-    - ReactCommon/turbomodule/bridging
-    - ReactCommon/turbomodule/core
-    - ReactNativeDependencies
-    - Yoga
   - React-NativeModulesApple (0.86.2):
     - hermes-engine
     - React-callinvoker
@@ -2762,7 +2740,6 @@ DEPENDENCIES:
   - react-native-image-picker (from `../node_modules/react-native-image-picker`)
   - react-native-safe-area-context (from `../node_modules/react-native-safe-area-context`)
   - react-native-view-shot (from `../node_modules/react-native-view-shot`)
-  - react-native-webview (from `../node_modules/react-native-webview`)
   - React-NativeModulesApple (from `../node_modules/react-native/ReactCommon/react/nativemodule/core/platform/ios`)
   - React-networking (from `../node_modules/react-native/ReactCommon/react/networking`)
   - React-oscompat (from `../node_modules/react-native/ReactCommon/oscompat`)
@@ -2940,8 +2917,6 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-safe-area-context"
   react-native-view-shot:
     :path: "../node_modules/react-native-view-shot"
-  react-native-webview:
-    :path: "../node_modules/react-native-webview"
   React-NativeModulesApple:
     :path: "../node_modules/react-native/ReactCommon/react/nativemodule/core/platform/ios"
   React-networking:
@@ -3117,7 +3092,6 @@ SPEC CHECKSUMS:
   react-native-image-picker: 23540feacc79c63c60857f318fdfa8477c26e70a
   react-native-safe-area-context: fb5c8ee9f6dd62ef710611b3d370c501f42a4ac0
   react-native-view-shot: 2829bd78c1fef42db12553bf85833e05a1a73609
-  react-native-webview: fc219e9deb92eb077f37828f4dd9267064835c9d
   React-NativeModulesApple: 167e532fb9bae30f3c66636b8ee0092bab263667
   React-networking: 89f6b69755a3176f30e56ba1ba8e214b1518ecfb
   React-oscompat: db6675ddaef3bddd1b41533627f3d26ec710c05f

--- a/Resonare/package-lock.json
+++ b/Resonare/package-lock.json
@@ -44,7 +44,6 @@
         "react-native-url-polyfill": "^3.0.0",
         "react-native-vector-icons": "^10.3.0",
         "react-native-view-shot": "^5.1.1",
-        "react-native-webview": "^15.0.0",
         "react-native-worklets": "^0.11.3",
         "react-redux": "^9.3.0"
       },
@@ -17412,20 +17411,6 @@
       "peerDependencies": {
         "react": ">=18.0.0",
         "react-native": ">=0.76.0"
-      }
-    },
-    "node_modules/react-native-webview": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/react-native-webview/-/react-native-webview-15.0.0.tgz",
-      "integrity": "sha512-uT7gjRgSXHHeRchwadG4Db4RTb5QqJgd1aWAu5IYlWfnOlzSWDg4BjJh71y9YiYDumHd/Z3V1LUarxeIrfr2nQ==",
-      "license": "MIT",
-      "dependencies": {
-        "escape-string-regexp": "^4.0.0",
-        "invariant": "2.2.4"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-native": "*"
       }
     },
     "node_modules/react-native-worklets": {

--- a/Resonare/package.json
+++ b/Resonare/package.json
@@ -53,7 +53,6 @@
     "react-native-url-polyfill": "^3.0.0",
     "react-native-vector-icons": "^10.3.0",
     "react-native-view-shot": "^5.1.1",
-    "react-native-webview": "^15.0.0",
     "react-native-worklets": "^0.11.3",
     "react-redux": "^9.3.0"
   },


### PR DESCRIPTION
Closes #186, which proposed bumping this to 16.0.0. **Removing it is strictly better than upgrading it — nothing uses it.**

## Verified unused before removing

- No `WebView` or `react-native-webview` reference anywhere in `src/`, `App.tsx`, `index.js`, or `__tests__`.
- `npm ls react-native-webview` shows it as a top-level dependency with **no dependents** — no transitive package pulls it in.

It was only ever bumped (13.16.0 → 15.0.0) during the RN 0.86 upgrade because 13.16.0 failed to compile against RN 0.86. Per the notes from that session it was a red herring even then — the actual build blocker turned out to be `react-native-view-shot`. So it's been carried as dead weight, compiling a native pod into every iOS build for no benefit.

## Effect

One fewer native pod. CocoaPods reports `Removing react-native-webview`:

| | Before | After |
|---|---|---|
| Podfile dependencies | 109 | 108 |
| Total pods installed | 127 | 126 |

The `Podfile.lock` diff is **26 deletions and zero additions** — entirely the webview pod block and its own dependency list. No other pod is touched.

## Verification

- `npm run lint` — 0 errors
- `npm test` — 18/18
- iOS build **SUCCEEDED**, 0 errors, and **zero** webview references anywhere in the build log
- Metro bundles cleanly — no unresolved imports
- App launches and renders the home feed with the AdMob banner intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)