### PR TITLE
deps: @react-native-community/datetimepicker 8.6.0 → 9.1.0

### DIFF
--- a/Resonare/ios/Podfile.lock
+++ b/Resonare/ios/Podfile.lock
@@ -2167,7 +2167,7 @@ PODS:
   - ReactNativeDependencies (0.86.2)
   - RNAppleAuthentication (2.5.1):
     - React-Core
-  - RNDateTimePicker (8.6.0):
+  - RNDateTimePicker (9.1.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -3154,7 +3154,7 @@ SPEC CHECKSUMS:
   ReactCommon: 9002f006f571256348994183f7d4387aa7cf84e8
   ReactNativeDependencies: 2bd6854ade79bf1b60586d1ab7813a389df1b6bf
   RNAppleAuthentication: a89c9804592b38ed4ab11f0aee68d05ba12ad432
-  RNDateTimePicker: b9e20c2a3af26f4ab10646359777205bbad1fdac
+  RNDateTimePicker: 7b2738f1e595f83c14580a11c476872755c5befc
   RNFastImage: 5fafd2e70056cf7729b1bdcd558a7f0fea2aff0e
   RNFBApp: 8cff8abd5e4cb59fc00415cb6226a12e19ad5e15
   RNFBCrashlytics: a238c90f07baa259de3f4ea148d4af8667aa1ccd

--- a/Resonare/package-lock.json
+++ b/Resonare/package-lock.json
@@ -12,7 +12,7 @@
         "@invertase/react-native-apple-authentication": "^2.5.1",
         "@react-native-async-storage/async-storage": "^3.1.1",
         "@react-native-camera-roll/camera-roll": "^7.10.2",
-        "@react-native-community/datetimepicker": "^8.6.0",
+        "@react-native-community/datetimepicker": "^9.1.0",
         "@react-native-firebase/app": "^26.0.0",
         "@react-native-firebase/crashlytics": "^26.0.0",
         "@react-native-firebase/messaging": "^26.0.0",
@@ -5704,9 +5704,9 @@
       }
     },
     "node_modules/@react-native-community/datetimepicker": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/@react-native-community/datetimepicker/-/datetimepicker-8.6.0.tgz",
-      "integrity": "sha512-yxPSqNfxgpGaqHQIpatqe6ykeBdU/1pdsk/G3x01mY2bpTflLpmVTLqFSJYd3MiZzxNZcMs/j1dQakUczSjcYA==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/datetimepicker/-/datetimepicker-9.1.0.tgz",
+      "integrity": "sha512-eadbnk+I2vxvW30iTAsm/qlCnMMAadkifIMYNEB2lzhxN/SvlKc7S2V4k5DyrwjdCbqdcMk3t9K6fnUMcAV34w==",
       "license": "MIT",
       "dependencies": {
         "invariant": "^2.2.4"

--- a/Resonare/package.json
+++ b/Resonare/package.json
@@ -21,7 +21,7 @@
     "@invertase/react-native-apple-authentication": "^2.5.1",
     "@react-native-async-storage/async-storage": "^3.1.1",
     "@react-native-camera-roll/camera-roll": "^7.10.2",
-    "@react-native-community/datetimepicker": "^8.6.0",
+    "@react-native-community/datetimepicker": "^9.1.0",
     "@react-native-firebase/app": "^26.0.0",
     "@react-native-firebase/crashlytics": "^26.0.0",
     "@react-native-firebase/messaging": "^26.0.0",


### PR DESCRIPTION
Replaces #187 (rebased onto current main, with the `pod install` and a real UI check Dependabot can't do).

## Breaking change assessment

v9.0.0's only documented breaking change is the removal of three deprecated **Android** props: `positiveButtonLabel`, `negativeButtonLabel`, `neutralButtonLabel`.

**This app uses none of them.** All three call sites pass only `value` / `mode` / `display` / `maximumDate` / `onChange` / `style`:

| Call site | Platform | Display |
|---|---|---|
| [AlbumDetailsScreen.tsx:862](Resonare/src/screens/Album/AlbumDetailsScreen.tsx:862) | iOS | `spinner` |
| [AlbumDetailsScreen.tsx:929](Resonare/src/screens/Album/AlbumDetailsScreen.tsx:929) | **Android-only** | `default` |
| [DiaryEntryDetailsScreen.tsx:931](Resonare/src/screens/Profile/DiaryEntryDetailsScreen.tsx:931) | both | `spinner` |

No code migration required.

**Native:** scoped `Podfile.lock` diff — `RNDateTimePicker` 8.6.0 → 9.1.0 only, with the codegen spec (`RNDateTimePickerCGen`) regenerated.

## Verification

- `npm run lint` — 0 errors
- `npm test` — 18/18
- `tsc` — zero picker-related errors, and total error count **unchanged at 215** vs baseline
- iOS build **SUCCEEDED**, 0 errors

Exercised the picker on the simulator via **Diary Entry → Edit Date**:

- spinner renders with the correct current value (July 13 2026)
- `maximumDate` respected — future years and months dimmed
- scrolling the day column 13 → 14 **fires `onChange`** (Save flips from disabled to enabled, which is app state driven by that callback)
- Cancel dismisses without mutating the entry

## Not verified

The Android call site at [AlbumDetailsScreen.tsx:929](Resonare/src/screens/Album/AlbumDetailsScreen.tsx:929). It's gated behind `Platform.OS === 'android'`, and v9's breaking change was Android-only — so the call site closest to the actual break is the one an iOS simulator can't reach. It passes none of the removed props, but that's a code reading, not a runtime check.

This folds into the broader Android gap outstanding since the RN 0.86 upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)