### PR TITLE
release: 1.1.0 prep — version bump, export compliance, Deezer in public policy

### DIFF
--- a/Resonare/ios/Resonare.xcodeproj/project.pbxproj
+++ b/Resonare/ios/Resonare.xcodeproj/project.pbxproj
@@ -357,7 +357,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.5;
+				MARKETING_VERSION = 1.1.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -387,7 +387,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.5;
+				MARKETING_VERSION = 1.1.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -670,7 +670,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.5;
+				MARKETING_VERSION = 1.1.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -788,7 +788,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.5;
+				MARKETING_VERSION = 1.1.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -897,7 +897,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.5;
+				MARKETING_VERSION = 1.1.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -1005,7 +1005,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.5;
+				MARKETING_VERSION = 1.1.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",

--- a/Resonare/ios/Resonare/Info.plist
+++ b/Resonare/ios/Resonare/Info.plist
@@ -43,6 +43,8 @@
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>GADApplicationIdentifier</key>
 	<string>ca-app-pub-5443760017915120~2653462969</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
 		<string>instagram-stories</string>
@@ -57,8 +59,6 @@
 		<key>NSAllowsLocalNetworking</key>
 		<true/>
 	</dict>
-	<key>NSLocationWhenInUseUsageDescription</key>
-	<string>This app uses location services to enhance your experience with location-based features.</string>
 	<key>NSPhotoLibraryAddUsageDescription</key>
 	<string>This app needs access to save diary entry images to your photo library.</string>
 	<key>NSPhotoLibraryUsageDescription</key>

--- a/Resonare/package.json
+++ b/Resonare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Resonare",
-  "version": "0.0.1",
+  "version": "1.1.0",
   "private": true,
   "scripts": {
     "android": "npx react-native run-android",

--- a/Resonare/src/services/crashAnalytics.ts
+++ b/Resonare/src/services/crashAnalytics.ts
@@ -54,9 +54,11 @@ class FirebaseCrashAnalytics implements CrashAnalyticsService {
 
       if (shouldCollect) {
         // Set initial app info for production/staging
+        // Note: app version/build are reported natively by Crashlytics from the
+        // bundle, so we deliberately do not set a custom app_version attribute —
+        // a hand-maintained copy only ever drifts out of date.
         crashlyticsModule.setAttributes(crashlyticsInstance, {
           environment: Environment.current,
-          app_version: '1.0.0', // TODO: Get from package.json or build config
           build_type: Environment.current,
         });
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -15,7 +15,7 @@
         <header>
             <h1>Privacy Policy</h1>
             <p class="app-name">Resonare</p>
-            <p class="last-updated">Last Updated: December 7, 2025</p>
+            <p class="last-updated">Last Updated: August 2, 2026</p>
         </header>
 
         <main>
@@ -71,7 +71,7 @@
                 <ul>
                     <li>Location data or GPS coordinates</li>
                     <li>Device identifiers for advertising purposes</li>
-                    <li>Access to your Spotify listening history or playlists</li>
+                    <li>Access to any streaming service account, listening history, or playlists</li>
                     <li>Browsing history outside the app</li>
                     <li>Contact lists or phone book data</li>
                     <li>Payment information (app is currently free)</li>
@@ -155,11 +155,12 @@
 
                 <h3>3.4 Music Data</h3>
                 <div class="service-card">
-                    <h4>Spotify Web API</h4>
-                    <p>Provides album metadata, artwork, and track listings. We do not access your Spotify account or
-                        listening history.</p>
-                    <p><a href="https://www.spotify.com/privacy" target="_blank" rel="noopener">Spotify Privacy
-                            Policy</a></p>
+                    <h4>Deezer API</h4>
+                    <p>Provides album metadata, artwork, and track listings. Requests are made by the app for the
+                        catalog data it displays; no Deezer account is required, and we do not access any Deezer
+                        account or listening history.</p>
+                    <p><a href="https://www.deezer.com/legal/personal-datas" target="_blank" rel="noopener">Deezer
+                            Privacy Policy</a></p>
                 </div>
             </section>
 
@@ -382,7 +383,7 @@
 
                 <h3>12.2 Third-Party Links</h3>
                 <p>
-                    Our app may contain links to third-party websites or services (such as Spotify album pages).
+                    Our app may contain links to third-party websites or services (such as Deezer album pages).
                     We are not responsible for the privacy practices of these third parties. We encourage you to read
                     their privacy policies.
                 </p>
@@ -406,7 +407,7 @@
                     <a href="child-safety.html">Child Safety</a> |
                     <a href="support.html">Support &amp; Feedback</a>
                 </p>
-                <p class="version">Privacy Policy Version 1.0 | Effective Date: December 7, 2025</p>
+                <p class="version">Privacy Policy Version 1.1 | Effective Date: August 2, 2026</p>
             </div>
         </footer>
     </div>

--- a/docs/terms.html
+++ b/docs/terms.html
@@ -15,7 +15,7 @@
         <header>
             <h1>Terms of Service</h1>
             <p class="app-name">Resonare</p>
-            <p class="last-updated">Last Updated: December 8, 2025</p>
+            <p class="last-updated">Last Updated: August 2, 2026</p>
         </header>
 
         <main>
@@ -173,7 +173,7 @@
 
                 <h3>7.2 Third-Party Content</h3>
                 <p>
-                    Album information, artwork, and metadata displayed in the App are provided by Spotify and remain the
+                    Album information, artwork, and metadata displayed in the App are provided by Deezer and remain the
                     property of their respective owners. We do not claim ownership of this content.
                 </p>
             </section>
@@ -283,7 +283,7 @@
                     <a href="child-safety.html">Child Safety</a> |
                     <a href="support.html">Support &amp; Feedback</a>
                 </p>
-                <p class="version">Terms of Service Version 1.0 | Effective Date: December 8, 2025</p>
+                <p class="version">Terms of Service Version 1.1 | Effective Date: August 2, 2026</p>
             </div>
         </footer>
     </div>


### PR DESCRIPTION
First release since the Deezer migration. Prepares everything that can be done in the repo; the archive itself still has to happen on your machine against a physical device.

## Version

`1.0.5` build 1 has been live since January 2026. This moves to **`1.1.0` build 1** — a new marketing version, so build 1 is valid. Increment `CURRENT_PROJECT_VERSION` for each subsequent TestFlight upload of 1.1.0.

## App changes

- **`ITSAppUsesNonExemptEncryption=false`** in Info.plist. Without it every upload stalls on a manual export-compliance answer before testers can install. The app uses only standard HTTPS.
- **Removed `NSLocationWhenInUseUsageDescription`.** Nothing in `src/` touches location — the app declared a permission it never requests, contradicting the privacy policy.
- **Removed the hardcoded `app_version: '1.0.0'` Crashlytics attribute.** It has been wrong in every release since it was added. Crashlytics reports the real bundle version natively.

## Public policy (resonare.app, linked from the App Store listing)

Spotify is gone from the privacy policy and terms — service card, "what we don't collect", third-party link example, and metadata attribution all now say Deezer. Dates and document versions bumped to 1.1 / 2026-08-02, as the policy commits us to doing.

## Deliberately not changed

- **Android** `versionName`/`versionCode` stay at 1.0.4/2. Android is unverified since RN 0.86 and isn't part of this release.
- **AdMob is still undisclosed in the privacy policy** — see the discussion below. That needs a decision, not a silent edit.

## Verification

`npm run lint` — 0 errors (1 pre-existing warning in `scripts/verify-deezer-data.ts`, present on main). `npm test` — 18/18. `plutil -lint` on Info.plist — OK.

Not verified here: the Release archive. That's the real gate and it needs a device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)